### PR TITLE
chore(release): publish 4.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.5] - 2026-05-06
+
 ### Changed
 
 - Updated `cc-plan` and `cc-investigate` with Roadmap Sync Gates so frozen planning and root-cause handoffs reconcile source RM progress before moving to `cc-do`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cc-devflow",
-    "version": "4.5.4",
+    "version": "4.5.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cc-devflow",
-            "version": "4.5.4",
+            "version": "4.5.5",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cc-devflow",
-    "version": "4.5.4",
+    "version": "4.5.5",
     "description": "Multi-platform CLI and skill pack for agent coding",
     "main": "bin/cc-devflow.js",
     "bin": {


### PR DESCRIPTION
## Summary
- Bump cc-devflow to 4.5.5
- Move Roadmap Sync Gates changelog notes into the 4.5.5 release section

## Test Plan
- [x] npm run adapt:check
- [x] npm run verify:examples
- [x] npm run verify:publish
- [x] npm test -- --runInBand
- [x] npm publish --dry-run --access public
- [x] npm publish --access public
- [x] npm view cc-devflow version
- [x] npx --yes cc-devflow@4.5.5 --help