### PR TITLE
feat(cc-plan): require lettered decision options

### DIFF
--- a/.claude/skills/cc-plan/CHANGELOG.md
+++ b/.claude/skills/cc-plan/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CC-Plan Skill Changelog
 
+## v3.7.8 - 2026-05-08
+
+- require decision-question options to use `A` / `B` / `C` letter labels instead of numeric `1` / `2` / `3` labels
+- clarify that `D1` / `D2` are question identifiers, while answer options remain lettered
+
 ## v3.7.7 - 2026-05-08
 
 - treat the full `REQ/FIX-<number>-<description>` change key as identity so duplicate numbers from parallel worktrees are valid

--- a/.claude/skills/cc-plan/PLAYBOOK.md
+++ b/.claude/skills/cc-plan/PLAYBOOK.md
@@ -32,7 +32,7 @@
 19. 退出前必须跑 Roadmap Sync Gate：`devflow/roadmap.json` 是真相源，`devflow/ROADMAP.md` 和 `devflow/BACKLOG.md` 只是投影；source RM 存在就回写，找不到才记录 no-op。
 20. PRD 的结构要吸收进 `planning/design.md`：用户视角的问题和方案、完整 user stories、实现决策、测试决策、out-of-scope 和 further notes；不要默认创建独立 `PRD.md`。
 21. 接口可测性必须在计划阶段解决：依赖尽量注入，结果尽量可返回和断言，系统边界 adapter 拆成具体操作，避免让测试用条件分支 mock 一个万能 fetcher。
-22. 需要用户判断时必须走固定 `D<N>` Decision Question：证据、推荐、2-3 个互斥选项、影响和 STOP 都要出现，答案写回 design / manifest。
+22. 需要用户判断时必须走固定 `D<N>` Decision Question：证据、推荐、2-3 个互斥的 `A/B/C` 字母选项、影响和 STOP 都要出现，答案写回 design / manifest；选项禁止用 `1/2/3`。
 
 ## Required Outputs
 

--- a/.claude/skills/cc-plan/SKILL.md
+++ b/.claude/skills/cc-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-plan
-version: 3.7.7
+version: 3.7.8
 description: Use when a requirement, roadmap item, or bug needs scope clarification, design decisions, and executable task breakdown before coding starts.
 triggers:
   - 帮我规划这个需求
@@ -44,7 +44,7 @@ entry_gate:
   - "For non-trivial designs, compare named option roles: minimal viable, ideal architecture, and optional hybrid. Do not default to smallest unless it best serves the goal."
   - Plan executable work as Red/Green/Refactor by default; identify the first failing test before any production implementation task, or write an explicit TDD exception with replacement evidence.
   - For behavior changes, freeze the spec-style test name, one logical behavior, public verification path, and interface-testability decision before task split.
-  - When user judgment is required, ask with the fixed `cc-plan` Decision Question Protocol (`D<N>`, evidence, recommendation, 2-3 options, impact, STOP) instead of free-form prose.
+  - When user judgment is required, ask with the fixed `cc-plan` Decision Question Protocol (`D<N>`, evidence, recommendation, lettered A/B/C options, impact, STOP) instead of free-form prose.
   - Assign a canonical change key before writing artifacts; feature work must use `REQ-<number>-<description>`, and bug-fix work must use `FIX-<number>-<description>`. REQ and FIX use independent local number sequences, and the full change key, including description, is the identity when parallel worktrees produce repeated numbers.
   - Do not generate planning/tasks.md, planning/task-manifest.json, or change-meta.json until the recommended design is approved.
   - Before exit, locate the source RM in `devflow/roadmap.json`, `devflow/ROADMAP.md`, optional `devflow/BACKLOG.md`, or legacy `devflow/roadmap-tracking.json`; plan the progress sync instead of relying on chat memory.
@@ -53,7 +53,7 @@ exit_criteria:
   - planning/tasks.md, planning/task-manifest.json, and change-meta.json are explicit enough that cc-do can continue without chat memory.
   - The task breakdown preserves test-first execution; failing-test tasks precede implementation tasks, refactor checkpoints are visible, and any TDD exception is justified.
   - "Testability decisions make the public seam natural: small interface, deep implementation, injected boundary dependencies, returned results where practical, and boundary mocks only where the system genuinely leaves the repo."
-  - Required user decisions were asked through numbered decision questions and recorded in `planning/design.md` / `task-manifest.json` instead of left in chat.
+  - Required user decisions were asked through numbered decision question IDs with lettered A/B/C options and recorded in `planning/design.md` / `task-manifest.json` instead of left in chat.
   - The source roadmap item has been synchronized to the frozen planning state, or `planning/design.md` and `change-meta.json` record why no roadmap update is valid.
   - 'Only one next step remains: enter cc-do.'
 reroutes:
@@ -248,7 +248,7 @@ PRD 的好处要进入 `planning/design.md`，不要变成第 5 个文件。`cc-
 
 `cc-plan` 不是自由聊天。只在用户答案会改变设计、任务或交付边界时提问；能从 repo evidence、roadmap handoff、spec、测试或 git history 确认的，不问用户。
 
-必须使用固定 `D<N>` 决策问题，而不是临场自由发挥。第一个问题是 `D1`，之后递增。每次只问一个决策点，并在问题后 STOP，等待用户回答；没有回答前不得继续写 `planning/tasks.md`、`task-manifest.json` 或 `change-meta.json`。
+必须使用固定 `D<N>` 决策问题，而不是临场自由发挥。第一个问题是 `D1`，之后递增。问题编号可以是数字，但用户选项只能是字母 `A` / `B` / `C`，禁止用 `1` / `2` / `3` 表示选项。每次只问一个决策点，并在问题后 STOP，等待用户回答；没有回答前不得继续写 `planning/tasks.md`、`task-manifest.json` 或 `change-meta.json`。
 
 触发点只允许这些 gate：
 
@@ -283,7 +283,7 @@ STOP: wait for the user answer before continuing.
 
 规则：
 
-1. 选项必须是 2-3 个互斥选择；不要输出开放式“大段想法”让用户自己整理。
+1. 选项必须是 2-3 个互斥选择，并且必须以 `A)` / `B)` / `C)` 开头；禁止输出 `1)` / `2)` / `3)` 或纯数字选项。
 2. 必须有推荐项，且推荐项标注 `(recommended)`；机械选择可以 auto-decide，但必须写进 decision log。
 3. 如果选项不是覆盖度差异，而是方向差异，`Completeness` 写 `different-kind` 并说明为什么不能打分。
 4. 每个选项都要说清 `Good` 与 `Cost/Risk`。没有代价的确认不是选择，应改为执行说明或 final approval。

--- a/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
+++ b/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
@@ -28,7 +28,7 @@
     ]
   },
   "planningMeta": {
-    "reqPlanSkillVersion": "3.7.6",
+    "reqPlanSkillVersion": "3.7.8",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-15T12:00:00.000Z",
     "approvedBy": "user",

--- a/.claude/skills/cc-plan/references/planning-contract.md
+++ b/.claude/skills/cc-plan/references/planning-contract.md
@@ -28,7 +28,7 @@
 24. review loop 必须有 attempt 上限和 stall reroute；不能靠无限 review 掩盖需求仍不清楚。
 25. Roadmap Sync Gate 必须在退出前闭合：source RM 存在就回写 `devflow/roadmap.json` 并重新生成 `devflow/ROADMAP.md` / `devflow/BACKLOG.md`；不存在就记录 no-op reason。
 26. PRD-grade requirement brief 必须并入 `planning/design.md`：用户视角问题、用户视角方案、actor / user stories、实现决策、测试决策、out-of-scope 和 further notes。默认不得额外产出 `PRD.md`。
-27. 需要用户判断时必须使用固定 Decision Question：`D<N>`、证据、推荐、2-3 个互斥选项、影响和 STOP 都必须出现；禁止用自由问句代替审批 gate。
+27. 需要用户判断时必须使用固定 Decision Question：`D<N>`、证据、推荐、2-3 个互斥的 `A/B/C` 字母选项、影响和 STOP 都必须出现；禁止用自由问句或 `1/2/3` 数字选项代替审批 gate。
 28. 所有用户决策必须写入 `planning/design.md` 的 `Decision Questions`，并同步到 `task-manifest.json.planningMeta.decisionQuestions`，不能只留在聊天里。
 
 ## Design Modes
@@ -83,7 +83,7 @@
 - gate：`planning-mode` / `ambiguity-blocker` / `approach-approval` / `taste-or-user-challenge` / `final-design-approval`
 - knownEvidence
 - recommendation
-- options
+- options：只能使用 `A` / `B` / `C` 作为 option id
 - userChoice
 - impact
 - status：`asked` / `answered` / `auto-decided`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `cc-plan` Decision Question options to require `A/B/C` lettered choices while keeping `D1` / `D2` as question IDs.
+
 ## [4.5.6] - 2026-05-08
 
 ### Changed

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -2,7 +2,7 @@
   "updatedAt": "2026-05-06",
   "skills": {
     "cc-roadmap": "5.0.0",
-    "cc-plan": "3.7.7",
+    "cc-plan": "3.7.8",
     "cc-investigate": "1.2.2",
     "cc-do": "1.6.2",
     "cc-check": "1.10.1",

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-06",
+  "updatedAt": "2026-05-08",
   "skills": {
     "cc-roadmap": "5.0.0",
     "cc-plan": "3.7.8",

--- a/docs/examples/full-design-blocked/README.md
+++ b/docs/examples/full-design-blocked/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.7.7`, `cc-do@1.6.2`, `cc-check@1.10.1`
+- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.7.8`, `cc-do@1.6.2`, `cc-check@1.10.1`
 
 This example shows a requirement that **looked executable**, but `cc-check` correctly stopped it and sent it back to `cc-plan`.
 

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/design.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-002.v2`
 - Design version: `design.v2`
-- CC-Plan skill version: `3.7.7`
+- CC-Plan skill version: `3.7.8`
 - Requirement ID: `REQ-002`
 - Design mode: `full-design`
 - Why not `tiny-design`: the feature crosses import parsing, invite rules, billing limits, duplicate handling, and audit logging

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
@@ -6,7 +6,7 @@
   "requirementId": "REQ-002",
   "requirementVersion": "REQ-002.v2",
   "planningMeta": {
-    "reqPlanSkillVersion": "3.7.7",
+    "reqPlanSkillVersion": "3.7.8",
     "designVersion": "design.v2",
     "approvedAt": null,
     "approvedBy": null,

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-002.v2`
 - Design version: `design.v2`
-- CC-Plan skill version: `3.7.7`
+- CC-Plan skill version: `3.7.8`
 - Source roadmap item: `RM-010`
 - Source roadmap version: `roadmap.v2`
 

--- a/docs/examples/local-handoff/README.md
+++ b/docs/examples/local-handoff/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.7.7`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
+- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.7.8`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
 
 This example shows verified work that is **ready to move forward**, but `cc-act` still chooses `local-handoff`.
 

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/design.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-003.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.7.7`
+- CC-Plan skill version: `3.7.8`
 - Requirement ID: `REQ-003`
 - Design mode: `tiny-design`
 - Why this stays `tiny-design`: the patch adds one export action inside the existing admin audit UI without changing data contracts

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
@@ -6,7 +6,7 @@
   "requirementId": "REQ-003",
   "requirementVersion": "REQ-003.v1",
   "planningMeta": {
-    "reqPlanSkillVersion": "3.7.7",
+    "reqPlanSkillVersion": "3.7.8",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-16T13:10:00.000Z",
     "approvedBy": "user",

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-003.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.7.7`
+- CC-Plan skill version: `3.7.8`
 - Source roadmap item: `RM-020`
 - Source roadmap version: `roadmap.v3`
 

--- a/docs/examples/pdca-loop/README.md
+++ b/docs/examples/pdca-loop/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.7.7`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
+- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.7.8`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
 
 This folder shows one minimal but complete `cc-roadmap -> cc-plan -> cc-do -> cc-check -> cc-act` loop.
 

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/design.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-001.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.7.7`
+- CC-Plan skill version: `3.7.8`
 - Requirement ID: `REQ-001`
 - Design mode: `tiny-design`
 - Why this stays `tiny-design`: the patch is limited to an existing dialog and test file, with no API or data model changes

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
@@ -22,7 +22,7 @@
     ]
   },
   "planningMeta": {
-    "reqPlanSkillVersion": "3.7.7",
+    "reqPlanSkillVersion": "3.7.8",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-15T10:05:00.000Z",
     "approvedBy": "user",

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-001.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.7.7`
+- CC-Plan skill version: `3.7.8`
 - Source roadmap item: `RM-001`
 - Source roadmap version: `roadmap.v1`
 

--- a/scripts/validate-publish.js
+++ b/scripts/validate-publish.js
@@ -182,6 +182,99 @@ function ensureWritesArray(value, label, errors) {
   }
 }
 
+function collectDecisionQuestionOptionErrors(manifest, label, errors) {
+  const questions = manifest?.planningMeta?.decisionQuestions || [];
+  if (!Array.isArray(questions)) {
+    errors.push(`${label}.planningMeta.decisionQuestions must be an array`);
+    return;
+  }
+
+  questions.forEach((question, questionIndex) => {
+    const options = question?.options || [];
+    const questionLabel = `${label}.planningMeta.decisionQuestions[${questionIndex}]`;
+
+    if (!Array.isArray(options) || options.length < 2 || options.length > 3) {
+      errors.push(`${questionLabel}.options must contain 2-3 lettered options`);
+      return;
+    }
+
+    const ids = new Set();
+    options.forEach((option, optionIndex) => {
+      const optionLabel = `${questionLabel}.options[${optionIndex}].id`;
+      const optionId = option?.id;
+
+      if (!/^[A-C]$/.test(optionId || '')) {
+        errors.push(`${optionLabel} must be A, B, or C; got ${JSON.stringify(optionId)}`);
+        return;
+      }
+
+      if (ids.has(optionId)) {
+        errors.push(`${questionLabel}.options must not repeat option id ${optionId}`);
+      }
+      ids.add(optionId);
+    });
+
+    const userChoice = question?.userChoice;
+    if (userChoice !== null && userChoice !== undefined && !ids.has(userChoice)) {
+      errors.push(`${questionLabel}.userChoice must match a lettered option id`);
+    }
+  });
+}
+
+function validateCcPlanDecisionQuestionContract(errors) {
+  const skill = fs.readFileSync(path.join(ROOT, '.claude/skills/cc-plan/SKILL.md'), 'utf8');
+  const fullDesign = fs.readFileSync(path.join(ROOT, '.claude/skills/cc-plan/assets/DESIGN_TEMPLATE.md'), 'utf8');
+  const manifestPath = path.join(ROOT, '.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json');
+  const planningContract = fs.readFileSync(
+    path.join(ROOT, '.claude/skills/cc-plan/references/planning-contract.md'),
+    'utf8'
+  );
+
+  const requiredSnippets = [
+    ['cc-plan SKILL.md', skill, '## Decision Question Protocol'],
+    ['cc-plan SKILL.md', skill, 'D<N> - <decision title>'],
+    ['cc-plan SKILL.md', skill, 'A) <label> (recommended)'],
+    ['cc-plan SKILL.md', skill, 'B) <label>'],
+    ['cc-plan SKILL.md', skill, '禁止输出 `1)` / `2)` / `3)`'],
+    ['cc-plan SKILL.md', skill, 'STOP: wait for the user answer before continuing.'],
+    ['cc-plan DESIGN_TEMPLATE.md', fullDesign, '## Decision Questions'],
+    ['cc-plan planning-contract.md', planningContract, 'options：只能使用 `A` / `B` / `C`']
+  ];
+
+  for (const [label, content, snippet] of requiredSnippets) {
+    if (!content.includes(snippet)) {
+      errors.push(`${label} missing decision-question snippet: ${snippet}`);
+    }
+  }
+
+  collectDecisionQuestionOptionErrors(
+    JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+    '.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json',
+    errors
+  );
+
+  const examplesRoot = path.join(ROOT, 'docs/examples');
+  for (const exampleName of fs.readdirSync(examplesRoot)) {
+    const changesRoot = path.join(examplesRoot, exampleName, 'changes');
+    if (!fs.existsSync(changesRoot)) {
+      continue;
+    }
+
+    for (const changeName of fs.readdirSync(changesRoot)) {
+      const exampleManifestPath = path.join(changesRoot, changeName, 'planning/task-manifest.json');
+      if (!fs.existsSync(exampleManifestPath)) {
+        continue;
+      }
+
+      collectDecisionQuestionOptionErrors(
+        JSON.parse(fs.readFileSync(exampleManifestPath, 'utf8')),
+        path.relative(ROOT, exampleManifestPath),
+        errors
+      );
+    }
+  }
+}
+
 function validatePublicSkillContracts(errors) {
   for (const skillName of PUBLIC_SKILLS) {
     const skillPath = path.join(ROOT, '.claude', 'skills', skillName, 'SKILL.md');
@@ -529,6 +622,7 @@ function main() {
   validatePackageJson(errors);
   validateTemplate(errors);
   validateInventoryParity(errors);
+  validateCcPlanDecisionQuestionContract(errors);
   validatePublicSkillContracts(errors);
   validateExampleBindings(errors);
   validatePackTarball(errors);
@@ -549,5 +643,6 @@ if (require.main === module) {
 }
 
 module.exports = {
+  collectDecisionQuestionOptionErrors,
   ensureStringArray
 };

--- a/test/validate-publish.test.js
+++ b/test/validate-publish.test.js
@@ -2,7 +2,10 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { spawnSync } = require('child_process');
-const { ensureStringArray } = require('../scripts/validate-publish');
+const {
+  collectDecisionQuestionOptionErrors,
+  ensureStringArray
+} = require('../scripts/validate-publish');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -90,5 +93,30 @@ describe('validate-publish', () => {
     expect(fullDesign).toContain('## Decision Questions');
     expect(manifest).toContain('"decisionQuestions"');
     expect(planningContract).toContain('options：只能使用 `A` / `B` / `C`');
+  });
+
+  test('rejects numeric decision option ids in planning manifests', () => {
+    const errors = [];
+
+    collectDecisionQuestionOptionErrors({
+      planningMeta: {
+        decisionQuestions: [
+          {
+            questionId: 'D1',
+            options: [
+              { id: '1', label: 'Numeric option' },
+              { id: '2', label: 'Another numeric option' }
+            ],
+            userChoice: '1'
+          }
+        ]
+      }
+    }, 'manifest', errors);
+
+    expect(errors).toEqual(expect.arrayContaining([
+      'manifest.planningMeta.decisionQuestions[0].options[0].id must be A, B, or C; got "1"',
+      'manifest.planningMeta.decisionQuestions[0].options[1].id must be A, B, or C; got "2"',
+      'manifest.planningMeta.decisionQuestions[0].userChoice must match a lettered option id'
+    ]));
   });
 });

--- a/test/validate-publish.test.js
+++ b/test/validate-publish.test.js
@@ -76,11 +76,19 @@ describe('validate-publish', () => {
       path.join(ROOT, '.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json'),
       'utf8'
     );
+    const planningContract = fs.readFileSync(
+      path.join(ROOT, '.claude/skills/cc-plan/references/planning-contract.md'),
+      'utf8'
+    );
 
     expect(skill).toContain('## Decision Question Protocol');
     expect(skill).toContain('D<N> - <decision title>');
+    expect(skill).toContain('A) <label> (recommended)');
+    expect(skill).toContain('B) <label>');
+    expect(skill).toContain('禁止输出 `1)` / `2)` / `3)`');
     expect(skill).toContain('STOP: wait for the user answer before continuing.');
     expect(fullDesign).toContain('## Decision Questions');
     expect(manifest).toContain('"decisionQuestions"');
+    expect(planningContract).toContain('options：只能使用 `A` / `B` / `C`');
   });
 });


### PR DESCRIPTION
## Summary
- Follow up the merged Decision Question Protocol with a stricter `A/B/C` option contract.
- Bump `cc-plan` to `3.7.8` and sync example bindings/manifests.
- Add publish-validator assertions so numeric `1/2/3` options cannot silently return.

## Scope Drift
Scope Check: CLEAN. The diff is limited to `cc-plan` contract docs, examples, changelog metadata, and validator coverage.

## Pre-Landing Review
No issues found in the scoped skill-contract diff.

## Design Review
No frontend files changed - design review skipped.

## Test plan
- [x] `jq empty .claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json`
- [x] `git diff --check HEAD~1..HEAD`
- [x] `npm test -- test/validate-publish.test.js --runInBand`
- [x] `npm test -- --runInBand`
- [x] `npm run verify:examples`
- [x] `npm run verify:publish`