### PR TITLE
feat(roadmap): add project direction gate

### DIFF
--- a/.claude/skills/cc-act/PLAYBOOK.md
+++ b/.claude/skills/cc-act/PLAYBOOK.md
@@ -182,7 +182,7 @@ Ship 必须属于这 4 种模式之一：
 
 ### destructive cleanup
 
-- 删除 branch、worktree、未合并提交、requirement archive 前，先列出对象
+- 删除 branch、worktree、未合并提交、change archive 前，先列出对象
 - 丢弃未合并工作必须要求用户显式确认
 - 无法确认时保留现场，切到 `local-handoff`
 
@@ -248,7 +248,7 @@ Ship 必须属于这 4 种模式之一：
 - `scripts/sync-act-docs.sh` 负责同步 requirement 级文档与 doc target 报告
 - `scripts/render-pr-brief.sh` 负责从 requirement 真相源渲染 `pr-brief.md`
 - `scripts/generate-status-report.sh` 负责汇总 requirement 与 ship 现状
-- `scripts/archive-requirement.sh` 负责 requirement 生命周期收尾
+- `scripts/archive-change.sh` 负责 change 生命周期收尾（归档到 `devflow/changes/archive/YYYY-MM/`）
 - `../cc-roadmap/scripts/locate-roadmap-item.sh` 负责定位 source RM
 - `../cc-roadmap/scripts/sync-roadmap-progress.sh` 负责回写 roadmap progress 并渲染投影
 - `cc-simplify` 负责在 ship 前压掉重复、坏味道、低效实现

--- a/.claude/skills/cc-act/SKILL.md
+++ b/.claude/skills/cc-act/SKILL.md
@@ -322,7 +322,7 @@ readiness dashboard 有 blocker 时，不能创建或更新 PR，只能 reroute 
    - 被推迟但必须保留的事项
    - 因本次结果而改变优先级的事项
 14. 用 `sync-roadmap-progress.sh` 更新 source RM 的 status、REQ/FIX 绑定和 progress：`create-pr` / `update-pr` 通常写 `In review` + `100%`，`local-handoff` 写 `Ready for handoff`，`post-merge-closeout` 写 `Done`；如果无 source RM，必须在 handoff 写 no-op reason。
-15. 如果 requirement 真正闭环，更新状态摘要并归档；否则把下一位接手者的入口写清楚。
+15. 如果 requirement 真正闭环，更新状态摘要并归档：运行 `cc-devflow archive-change <change-key>` 将已完成变更移入 `devflow/changes/archive/YYYY-MM/`；否则把下一位接手者的入口写清楚。
 
 ## Output
 
@@ -359,7 +359,7 @@ readiness dashboard 有 blocker 时，不能创建或更新 PR，只能 reroute 
 - Ship 目标识别：`scripts/detect-ship-target.sh`
 - 文档同步：`scripts/sync-act-docs.sh`
 - PR 简报生成：`scripts/render-pr-brief.sh`
-- requirement 归档：`scripts/archive-requirement.sh`
+- 变更归档：`scripts/archive-change.sh`
 - Roadmap 定位：`../cc-roadmap/scripts/locate-roadmap-item.sh`
 - Roadmap 回写：`../cc-roadmap/scripts/sync-roadmap-progress.sh`
 

--- a/.claude/skills/cc-act/scripts/archive-change.sh
+++ b/.claude/skills/cc-act/scripts/archive-change.sh
@@ -3,25 +3,25 @@
 set -euo pipefail
 
 # ------------------------------------------------------------
-# 归档或恢复 requirement 目录
+# 归档或恢复 change 目录
 # ------------------------------------------------------------
 
 usage() {
   cat <<'EOF'
 Usage:
-  archive-requirement.sh --req-dir path/to/REQ-001 --archive-root devflow/archive
-  archive-requirement.sh --restore path/to/archive/2026-04/REQ-001 --active-root devflow/requirements
+  archive-change.sh --change-dir devflow/changes/REQ-001-feature --archive-root devflow/changes/archive
+  archive-change.sh --restore devflow/changes/archive/2026-04/REQ-001-feature --active-root devflow/changes
 EOF
 }
 
-REQ_DIR=""
+CHANGE_DIR=""
 ARCHIVE_ROOT=""
 RESTORE=""
 ACTIVE_ROOT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --req-dir) REQ_DIR="$2"; shift 2 ;;
+    --change-dir) CHANGE_DIR="$2"; shift 2 ;;
     --archive-root) ARCHIVE_ROOT="$2"; shift 2 ;;
     --restore) RESTORE="$2"; shift 2 ;;
     --active-root) ACTIVE_ROOT="$2"; shift 2 ;;
@@ -38,12 +38,12 @@ if [[ -n "$RESTORE" ]]; then
   exit 0
 fi
 
-if [[ -z "$REQ_DIR" || -z "$ARCHIVE_ROOT" || ! -d "$REQ_DIR" ]]; then
+if [[ -z "$CHANGE_DIR" || -z "$ARCHIVE_ROOT" || ! -d "$CHANGE_DIR" ]]; then
   usage
   exit 1
 fi
 
 month="$(date '+%Y-%m')"
 mkdir -p "$ARCHIVE_ROOT/$month"
-mv "$REQ_DIR" "$ARCHIVE_ROOT/$month/"
+mv "$CHANGE_DIR" "$ARCHIVE_ROOT/$month/"
 echo "Archived to $ARCHIVE_ROOT/$month"

--- a/.claude/skills/cc-roadmap/CHANGELOG.md
+++ b/.claude/skills/cc-roadmap/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roadmap Skill Changelog
 
+## v5.1.0 - 2026-05-09
+
+- add project-direction routing and brand-neutral founder guardrails
+
 ## v5.0.0 - 2026-05-01
 
 - replace the roadmap/backlog/tracking split with `devflow/roadmap.json` as the single editable roadmap state

--- a/.claude/skills/cc-roadmap/SKILL.md
+++ b/.claude/skills/cc-roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-roadmap
-version: 5.0.0
+version: 5.1.0
 description: "Use when defining, resetting, or narrowing project direction, stage order, or backlog priority before a concrete requirement enters the PDCA loop."
 triggers:
   - "帮我定路线图"
@@ -37,6 +37,7 @@ entry_gate:
   - "Read current roadmap, backlog, related capability specs, and surrounding repo context before proposing direction."
   - "Load cc-devflow native language and durable-decision sources (`devflow/specs/`, current roadmap/backlog, prior `planning/design.md` or `planning/analysis.md`, and `change-meta.json`) before naming stages, capabilities, users, or backlog items."
   - "Confirm this is a project-direction problem, not a single requirement execution problem."
+  - "Run the Project Direction Gate before evidence-maturity routing: classify the user's goal as founder/business, internal company project, hackathon/demo, open-source/research, learning, side project, infrastructure, or recovery."
   - "Classify planning posture and evidence maturity before selecting the route or forcing questions."
   - "If the ask contains multiple independent subsystems, decompose them into stages and RM candidates before refining any implementation detail."
   - "Do not decompose implementation tasks while the roadmap is still being decided."
@@ -107,6 +108,35 @@ tool_budget:
 
 先给一个**默认推荐**，再解释为什么，不要把用户扔进开放式战略讨论。
 
+## Project Direction Gate
+
+`cc-roadmap` 的第一道门不是功能优先级，而是项目目标。目标不同，问题就不同；问题问错，后面的路线图全都会偏。
+
+先用 repo 事实和用户原话判断 `project_direction_mode`。能判断就写入 `Context Snapshot`；不能判断才问一次：
+
+> 这次 roadmap 的目标是什么：做成业务、公司内部项目、限时 demo、开源/研究、学习、兴趣副项目、基础设施，还是事故恢复？
+
+不要让用户在 8 个选项里填表。先给默认判断和理由，再问用户是否纠正。
+
+| Mode | 用来判断的信号 | 追问重点 | 默认路线偏好 |
+| --- | --- | --- | --- |
+| `founder-business` | 用户提到客户、收入、市场、获客、创业、商业化 | 需求真实性、现状替代方案、具体人、最窄付费 wedge、观察到的行为、未来 6-12 个月为何更重要 | `wedge-first` |
+| `internal-company` | 用户提到老板、VP、团队落地、内部流程、审批、交付窗口 | sponsor 是谁、最小可批准 demo、组织依赖、reorg 风险、上线后的维护责任 | `rescue-first` 或 `wedge-first` |
+| `hackathon-demo` | 用户提到比赛、演示、deadline、惊艳效果 | 最快可展示路径、单一 wow moment、失败兜底、demo 环境和分发方式 | `wedge-first` |
+| `open-source-research` | 用户提到社区、论文、协议、benchmark、开源生态 | 贡献者是谁、现有替代品、可复现实验、维护边界、adoption path | `platform-first` 或 `wedge-first` |
+| `learning` | 用户提到学习、练手、理解框架、能力提升 | 要学会什么、最小练习闭环、可观察反馈、不要用过度架构遮住学习目标 | `wedge-first` |
+| `side-project` | 用户提到兴趣、好玩、创意表达、自用工具 | 最酷可分享版本、自己会不会每天用、最快可用路径、哪些想法可以 later | `wedge-first` |
+| `infrastructure` | 用户提到底座、运行时、CI、发布、安全、稳定性 | 调用方、当前 workaround、迁移/回滚、复用边界、失败成本 | `platform-first` 或 `rescue-first` |
+| `recovery` | 用户提到事故、信任、质量、回归、坏味道 | 事故证据、最小可信修复、停止扩张条件、恢复信任的验收信号 | `rescue-first` |
+
+Founder/business 模式可以给 brand-neutral 的创业建议，但只能作为路线判断，不准变成广告：
+
+- 可以建议：先和真实用户谈、验证付费或强行为、缩小到本周能交付的 wedge、观察用户不用帮助时怎么失败、把资源放在最强需求证据上。
+- 不可以建议：申请某个机构、加入某个项目、引用某个品牌权威、输出推广链接、把路线图写成融资材料。
+- 如果要推荐外部学习材料，必须先走隐私与外部查找 gate，只搜索泛化主题，并把结果写成 `external-evidence`；不要把任何品牌背书写进 roadmap 合同。
+
+Builder 模式（hackathon、open-source/research、learning、side-project）不要套创业拷问。它要逼清楚“什么值得展示 / 使用 / 复现 / 学会”，然后把路线压到最快能产生真实反馈的阶段。
+
 ## Harness Contract
 
 - Allowed actions: read current strategy files, repo context, and recent reality; compare route shapes; decompose independent subsystems into stages and RM candidates; write `devflow/roadmap.json` as the editable roadmap state, then generate `devflow/ROADMAP.md` and the deprecated `devflow/BACKLOG.md` compatibility projection from that state.
@@ -140,6 +170,23 @@ tool_budget:
 
 先把这些材料压成一个 `Context Snapshot`，再开始追问用户。
 
+## Direction-Specific Question Routing
+
+Project Direction Gate 先决定问哪组问题，Evidence-Maturity Routing 再决定问多深。不要对 founder、学习项目、基础设施和事故恢复使用同一套问题。
+
+| Direction mode | 必问问题 | 可跳过问题 |
+| --- | --- | --- |
+| `founder-business` | 谁今天真的痛；他们现在怎么绕路；最强 demand evidence 是行为、钱还是 workflow 绑定；本周最窄可付费 wedge 是什么；用户不被引导时会在哪里卡住；6-12 个月后为什么更需要它 | 长期平台组件、宽泛市场口号、还没有证据的增长规划 |
+| `internal-company` | sponsor 或决策人是谁；最小 demo 如何换来绿灯；上线后谁维护；依赖哪个团队；如果 champion 离开是否还成立 | 对外市场叙事、消费者增长、无 owner 的平台愿景 |
+| `hackathon-demo` | 评委或观众先看到什么；30-90 秒内的 wow moment；demo 失败时的备用路径；哪些功能必须假装不存在 | 完整权限体系、长期迁移、复杂可观测性 |
+| `open-source-research` | 现有替代品是什么；可复现实验或 benchmark 是什么；贡献者 first success path；维护者不想承担什么 | 商业销售漏斗、封闭分发、无法复现的主观评价 |
+| `learning` | 学会哪个概念；最小练习闭环；如何知道自己学会了；哪些抽象会遮住学习目标 | 生产级平台、过早优化、团队流程 |
+| `side-project` | 自己会不会反复用；最酷可分享版本；最快可用路径；哪些点只是好玩但不该阻塞 Stage 1 | 商业化压力、企业级集成、长期治理 |
+| `infrastructure` | 调用方是谁；今天的 workaround；失败成本；迁移与回滚；复用边界；谁会被 breaking change 影响 | 虚构 persona、营销故事、未证明的功能扩张 |
+| `recovery` | 哪个事故或坏味道触发；最小可信修复；防回归证据；继续扩张的 kill signal；用户信任如何恢复 | 新功能愿景、平台升级、没有事故证据的重构 |
+
+如果用户后续回答改变了 direction mode，必须重算 route shape，不要沿用旧问题继续问。
+
 ## Evidence-Maturity Routing
 
 不要对所有项目套同一组问题。先用 `planning posture` 和 `evidence maturity` 决定追问深度：
@@ -165,12 +212,25 @@ tool_budget:
 5. 每条路线都要用一个具体 scenario 压测：谁在什么约束下，今天如何绕路，Stage 1 完成后哪一步不再发生。
 6. 硬决策才沉淀：只有 hard to reverse、surprising without context、real trade-off 三者同时成立，才进入 capability spec delta、roadmap decision note 或本次 design decision log。
 
+## Founder Advice Guardrail
+
+创业建议只能服务于 roadmap 质量，不是推广内容。遇到 `founder-business` 或 `internal-company`：
+
+1. 强制把泛泛“有市场 / 用户感兴趣”改写为可观察证据：付费、强复用、工作流绑定、停机时焦虑、主动催上线。
+2. 强制找 status quo：手工流程、表格、脚本、外包、人肉客服、现有竞品、内部工具。没有现状替代方案时，先怀疑痛点不够痛。
+3. 强制命名具体人或具体角色，不接受“企业客户”“开发者”“内容团队”这类类别词作为用户。
+4. 强制压出最窄 wedge：本周能让一个真实用户付出钱、时间、迁移成本或组织信用的版本。
+5. 强制保留观察任务：如果还没看用户独立使用，Stage 1 必须包含观察或真实反馈信号。
+6. 严禁输出品牌广告、申请建议、推广链接或“某机构会喜欢”之类的权威背书。
+
+如果用户明确要创业方向资源，也只能给 source-neutral 的行动建议：找 3 个具体用户、看一次真实使用、验证一次付费或强行为、把 Stage 1 缩到一周内可交付。外部材料必须走外部查找 gate。
+
 ## Session Protocol
 
 1. 先探索上下文，不靠默认上下文注入替代阅读。
-2. 先问现实，不先写愿景。
+2. 先跑 Project Direction Gate，再问现实，不先写愿景。
 3. 一次只推进一个关键未知点，不要一口气抛一串问题。
-4. 先写 `Context Snapshot`、planning posture、evidence maturity、证据、约束、非目标，再讨论阶段。
+4. 先写 `Context Snapshot`、project direction mode、planning posture、evidence maturity、证据、约束、非目标，再讨论阶段。
 5. 给出 2-3 种路线图形状，再明确推荐一种，并说明为什么其他路线现在不值得打。
 6. 如果一个方向里有多个可独立交付的子系统，先写清 decomposition：哪些合并为同一阶段，哪些拆成独立 `RM`，为什么。
 7. 只冻结 1-3 个阶段。每个阶段都必须有 goal、why now、dependencies、exit signal、kill signal、non-goals。
@@ -199,7 +259,11 @@ tool_budget:
 
 ## Ask
 
-至少要逼清这 5 件事：
+至少要先逼清这 1 件事：
+
+0. 这次 roadmap 的目标模式是什么，以及为什么不是其它模式
+
+再逼清这 5 件事：
 
 1. 这个项目真正服务谁
 2. 用户今天用什么笨办法解决
@@ -225,7 +289,7 @@ tool_budget:
 ## Approval Gates
 
 1. 没有 `Context Snapshot`，不准给路线推荐。
-2. 没有 planning posture、evidence maturity 和 framing check，不准给路线推荐。
+2. 没有 project direction mode、planning posture、evidence maturity 和 framing check，不准给路线推荐。
 3. 没有 native language / durable decision scan，不准给路线推荐；如果缺少 `devflow/specs/` 或历史决策材料，写成 `not present`，不要假装已对齐。
 4. 没有 2-3 条路线对比，不准直接拍脑袋定主线。
 5. 没有 exit signal / kill signal / non-goals，不算阶段冻结。
@@ -248,9 +312,11 @@ tool_budget:
 7. Decomposition scan：多个独立子系统是否已拆成阶段 / `RM` 候选，而不是塞进一个含糊阶段。
 8. Handoff scan：第一批 roadmap item 是否已经自然长成可进入 `cc-plan` 的对象。
 9. Evidence maturity scan：问题路由是否匹配 idea / user / paying / infra / recovery 状态，还是拿同一套问题硬套所有项目。
-10. Adoption scan：developer-facing / operator-facing item 是否写清目标人、time to first value、magic moment 和 adoption bottleneck。
-11. Domain language scan：stage、capability、RM title、backlog handoff 是否沿用项目语言；冲突是否显式交给下一轮决策。
-12. Durable decision scan：路线是否违背既有 capability spec、roadmap decision 或历史 design decision；如需重开，是否说明为什么值得重开。
+10. Project direction scan：问题和路线是否匹配 founder-business / internal / demo / OSS / learning / side-project / infra / recovery；是否错误套用了创业问题或 builder 问题。
+11. Promotional scan：roadmap 是否没有品牌广告、申请建议、推广链接或外部权威背书；创业建议是否只保留 source-neutral 行动和证据要求。
+12. Adoption scan：developer-facing / operator-facing item 是否写清目标人、time to first value、magic moment 和 adoption bottleneck。
+13. Domain language scan：stage、capability、RM title、backlog handoff 是否沿用项目语言；冲突是否显式交给下一轮决策。
+14. Durable decision scan：路线是否违背既有 capability spec、roadmap decision 或历史 design decision；如需重开，是否说明为什么值得重开。
 
 ## Output
 

--- a/.claude/skills/cc-roadmap/assets/BACKLOG_TEMPLATE.md
+++ b/.claude/skills/cc-roadmap/assets/BACKLOG_TEMPLATE.md
@@ -26,6 +26,9 @@
 
 ## Adoption Handoff
 
+- Project direction mode:
+- Direction-specific first question:
+- Founder / builder / infra guardrail:
 - Planning posture:
 - Evidence maturity:
 - Target developer / operator:

--- a/.claude/skills/cc-roadmap/assets/ROADMAP_TEMPLATE.md
+++ b/.claude/skills/cc-roadmap/assets/ROADMAP_TEMPLATE.md
@@ -16,6 +16,8 @@
 ## Context Snapshot
 
 - Product / repo:
+- Project direction mode:
+- Direction mode rationale:
 - Planning posture:
 - Project stage:
 - Evidence maturity:
@@ -89,6 +91,10 @@
 
 ## Evidence-Maturity Routing
 
+- Project direction mode:
+- Direction-specific questions selected:
+- Direction-specific questions skipped:
+- Founder / builder / infra guardrails applied:
 - Planning posture:
 - Evidence maturity:
 - Questions selected:
@@ -200,6 +206,8 @@ flowchart TD
 - Rejected path A:
 - Rejected path B:
 - Rejected maturity route:
+- Project direction mode decision:
+- Promotional / brand-neutrality check:
 - Language / spec decision conflicts:
 - Developer / operator adoption assumptions:
 - Open assumptions to verify next:

--- a/.claude/skills/cc-roadmap/assets/TRACKING_TEMPLATE.json
+++ b/.claude/skills/cc-roadmap/assets/TRACKING_TEMPLATE.json
@@ -5,12 +5,17 @@
   },
   "meta": {
     "roadmapVersion": "roadmap.v1",
-    "skillVersion": "5.0.0",
+    "skillVersion": "5.1.0",
     "status": "active",
     "lastUpdated": "2026-05-01",
     "currentFocusStage": "Stage 1"
   },
   "context": {
+    "projectDirectionMode": "",
+    "projectDirectionRationale": "",
+    "directionQuestionsSelected": [],
+    "directionQuestionsSkipped": [],
+    "directionGuardrailsApplied": [],
     "planningPosture": "",
     "evidenceMaturity": "",
     "canonicalTerms": [],

--- a/.claude/skills/cc-roadmap/references/roadmap-dialogue.md
+++ b/.claude/skills/cc-roadmap/references/roadmap-dialogue.md
@@ -3,19 +3,20 @@
 ## Order
 
 0. 先做 `Context Snapshot`：现有 roadmap / backlog、capability specs、历史 design/analysis、最近提交、forcing functions、项目语言 / durable decisions
-1. 用户是谁
-2. 今天靠什么笨办法活着
-3. 最强需求证据是什么
-4. 为什么现在必须解决
-5. deadline / capacity / dependency / distribution 约束是什么
-6. 当前最大的 adoption / trust / delivery 卡点是什么
-7. 核心术语是否已有 canonical definition，是否和现有 capability spec / roadmap decision 冲突
-8. 最窄突破口是什么
-9. 6-12 个月后会长成什么
-10. 给出 2-3 条路线图形状并明确推荐
-11. 冻结 1-3 个阶段，写 exit signal / kill signal / non-goals
-12. 画出 `RM dependency graph`，标出串行主链和 parallel-ready wave
-13. 标出哪些事项真的 ready for `cc-plan`
+1. 先判断 project direction mode：founder-business / internal-company / hackathon-demo / open-source-research / learning / side-project / infrastructure / recovery
+2. 用户是谁
+3. 今天靠什么笨办法活着
+4. 最强需求证据是什么
+5. 为什么现在必须解决
+6. deadline / capacity / dependency / distribution 约束是什么
+7. 当前最大的 adoption / trust / delivery 卡点是什么
+8. 核心术语是否已有 canonical definition，是否和现有 capability spec / roadmap decision 冲突
+9. 最窄突破口是什么
+10. 6-12 个月后会长成什么
+11. 给出 2-3 条路线图形状并明确推荐
+12. 冻结 1-3 个阶段，写 exit signal / kill signal / non-goals
+13. 画出 `RM dependency graph`，标出串行主链和 parallel-ready wave
+14. 标出哪些事项真的 ready for `cc-plan`
 
 ## Question Rules
 
@@ -25,11 +26,25 @@
 - 没证据时明确写 assumption
 - 用户没批准前，不把事项偷下放成 requirement
 
+## Project Direction Modes
+
+- `founder-business`: 问 demand reality、status quo、specific human、narrowest paid wedge、observed behavior、future fit。允许给创业行动建议，但必须 source-neutral：找具体用户、看真实使用、验证付费或强行为、缩小本周 wedge。禁止品牌广告、申请建议、推广链接和外部权威背书。
+- `internal-company`: 问 sponsor、最小可批准 demo、组织依赖、维护 owner、reorg 风险。不要写对外市场叙事。
+- `hackathon-demo`: 问 wow moment、demo path、fallback、时间盒。不要先设计长期平台。
+- `open-source-research`: 问替代品、可复现 benchmark、贡献者 first success、维护边界。不要套商业销售漏斗。
+- `learning`: 问要学会什么、最小练习闭环、反馈方式。不要让生产级架构遮住学习目标。
+- `side-project`: 问自己会不会反复用、最酷可分享版本、最快可用路径。不要强行商业化。
+- `infrastructure`: 问调用方、workaround、失败成本、迁移/回滚、复用边界。不要虚构用户访谈。
+- `recovery`: 问事故证据、最小可信修复、防回归、kill signal、信任恢复。不要扩张新功能。
+
+如果 direction mode 变了，回到 route selection 重新算，不要沿用前一组问题。
+
 ## Route Shapes
 
 - `wedge-first`: 先用一个窄切口打穿真实需求
 - `platform-first`: 先做后面几阶段都会反复复用的底座
 - `rescue-first`: 先解决 adoption、trust、delivery 里最大的卡点
+- `decompose-first`: 先拆多个可独立交付系统，再决定每个系统的路线
 
 ## Output Rules
 

--- a/.claude/skills/cc-roadmap/scripts/lib/roadmap-tracking/markdown.js
+++ b/.claude/skills/cc-roadmap/scripts/lib/roadmap-tracking/markdown.js
@@ -621,6 +621,20 @@ function renderParked(tracking) {
     .join('\n\n');
 }
 
+function renderProjectDirectionHandoff(tracking) {
+  const context = tracking.context || {};
+
+  return [
+    `- Project direction mode: ${formatBacklogValue(context.projectDirectionMode)}`,
+    `- Direction mode rationale: ${formatBacklogValue(context.projectDirectionRationale)}`,
+    `- Direction-specific questions selected: ${formatList(context.directionQuestionsSelected || [])}`,
+    `- Direction-specific questions skipped: ${formatList(context.directionQuestionsSkipped || [])}`,
+    `- Direction guardrails applied: ${formatList(context.directionGuardrailsApplied || [])}`,
+    `- Planning posture: ${formatBacklogValue(context.planningPosture)}`,
+    `- Evidence maturity: ${formatBacklogValue(context.evidenceMaturity)}`
+  ].join('\n');
+}
+
 function renderBacklogDocument({ backlogFile, trackingFile, tracking }) {
   const relativePath = path.relative(path.dirname(backlogFile), trackingFile).replace(/\\/g, '/');
   const displayPath = relativePath || path.basename(trackingFile);
@@ -650,6 +664,10 @@ function renderBacklogDocument({ backlogFile, trackingFile, tracking }) {
     `- Serial spine: ${formatBacklogValue(tracking.dependencyHandoff.serialSpine)}`,
     `- Parallel-ready next wave: ${formatBacklogValue(tracking.dependencyHandoff.parallelReadyNextWave)}`,
     `- Notes on blockers: ${formatBacklogValue(tracking.dependencyHandoff.notesOnBlockers)}`,
+    '',
+    '## Project Direction Handoff',
+    '',
+    renderProjectDirectionHandoff(tracking),
     '',
     '## Ready For Req-Plan',
     '',

--- a/.claude/skills/cc-roadmap/scripts/lib/roadmap-tracking/schema.js
+++ b/.claude/skills/cc-roadmap/scripts/lib/roadmap-tracking/schema.js
@@ -78,6 +78,11 @@ const DEFAULT_ROADMAP_STATE = {
     currentFocusStage: ''
   },
   context: {
+    projectDirectionMode: '',
+    projectDirectionRationale: '',
+    directionQuestionsSelected: [],
+    directionQuestionsSkipped: [],
+    directionGuardrailsApplied: [],
     planningPosture: '',
     evidenceMaturity: '',
     canonicalTerms: [],
@@ -282,6 +287,9 @@ function normalizeRoadmapState(raw = {}) {
     context: {
       ...DEFAULT_ROADMAP_STATE.context,
       ...context,
+      directionQuestionsSelected: normalizeStringList(context.directionQuestionsSelected),
+      directionQuestionsSkipped: normalizeStringList(context.directionQuestionsSkipped),
+      directionGuardrailsApplied: normalizeStringList(context.directionGuardrailsApplied),
       canonicalTerms: normalizeStringList(context.canonicalTerms),
       durableDecisionSources: normalizeStringList(context.durableDecisionSources)
     },

--- a/bin/cc-devflow-cli.js
+++ b/bin/cc-devflow-cli.js
@@ -61,6 +61,9 @@ Commands:
   query list          List typed runtime query ids
   query <id>          Run a typed runtime query as JSON
   next-change-key     Compute the next REQ/FIX change key
+  archive-change      Archive a completed change to devflow/changes/archive/YYYY-MM/
+  restore-change      Restore an archived change back to devflow/changes/
+  list-archived       List all archived changes
 
 Init options:
   --dir <path>         Target project path (default: cwd)
@@ -602,6 +605,75 @@ function runAdapter(command, args) {
   return typeof result.status === 'number' ? result.status : 1;
 }
 
+function runArchiveChange(args) {
+  const parsed = { changeKey: null, cwd: null };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--cwd') { parsed.cwd = args[++i]; continue; }
+    if (arg.startsWith('--cwd=')) { parsed.cwd = arg.slice('--cwd='.length); continue; }
+    if (!arg.startsWith('-') && !parsed.changeKey) { parsed.changeKey = arg; continue; }
+  }
+
+  if (!parsed.changeKey) {
+    console.error('Use: cc-devflow archive-change <change-key> [--cwd path]');
+    return 1;
+  }
+
+  const { archiveChange } = require(path.join(PACKAGE_ROOT, 'lib/skill-runtime/archive-change.js'));
+  const repoRoot = path.resolve(parsed.cwd || process.cwd());
+  const result = archiveChange(repoRoot, parsed.changeKey);
+  process.stdout.write(`Archived to ${result.archived}\n`);
+  return 0;
+}
+
+function runRestoreChange(args) {
+  const parsed = { archivedPath: null, cwd: null };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--cwd') { parsed.cwd = args[++i]; continue; }
+    if (arg.startsWith('--cwd=')) { parsed.cwd = arg.slice('--cwd='.length); continue; }
+    if (!arg.startsWith('-') && !parsed.archivedPath) { parsed.archivedPath = arg; continue; }
+  }
+
+  if (!parsed.archivedPath) {
+    console.error('Use: cc-devflow restore-change <archived-path> [--cwd path]');
+    return 1;
+  }
+
+  const { restoreChange } = require(path.join(PACKAGE_ROOT, 'lib/skill-runtime/archive-change.js'));
+  const repoRoot = path.resolve(parsed.cwd || process.cwd());
+  const archivePath = path.resolve(parsed.archivedPath);
+  const result = restoreChange(repoRoot, archivePath);
+  process.stdout.write(`Restored to ${result.restored}\n`);
+  return 0;
+}
+
+function runListArchived(args) {
+  const parsed = { cwd: null };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--cwd') { parsed.cwd = args[++i]; continue; }
+    if (arg.startsWith('--cwd=')) { parsed.cwd = arg.slice('--cwd='.length); continue; }
+  }
+
+  const { listArchived } = require(path.join(PACKAGE_ROOT, 'lib/skill-runtime/archive-change.js'));
+  const repoRoot = path.resolve(parsed.cwd || process.cwd());
+  const items = listArchived(repoRoot);
+
+  if (items.length === 0) {
+    process.stdout.write('No archived changes.\n');
+    return 0;
+  }
+
+  for (const item of items) {
+    process.stdout.write(`${item.month}  ${item.changeKey}\n`);
+  }
+  return 0;
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   const [command, ...rest] = argv;
@@ -629,6 +701,18 @@ async function main() {
 
   if (command === 'next-change-key') {
     return runNextChangeKey(rest);
+  }
+
+  if (command === 'archive-change') {
+    return runArchiveChange(rest);
+  }
+
+  if (command === 'restore-change') {
+    return runRestoreChange(rest);
+  }
+
+  if (command === 'list-archived') {
+    return runListArchived(rest);
   }
 
   return runAdapter(command, rest);

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -1,7 +1,7 @@
 {
   "updatedAt": "2026-05-09",
   "skills": {
-    "cc-roadmap": "5.0.0",
+    "cc-roadmap": "5.1.0",
     "cc-plan": "3.8.0",
     "cc-investigate": "1.3.0",
     "cc-do": "1.6.2",

--- a/docs/examples/full-design-blocked/BACKLOG.md
+++ b/docs/examples/full-design-blocked/BACKLOG.md
@@ -5,7 +5,7 @@
 ## Backlog Meta
 
 - Roadmap version: `roadmap.v2`
-- Skill version: `5.0.0`
+- Skill version: `5.1.0`
 - Last synced: `2026-04-19`
 - Current focus stage: `Stage 2`
 - Roadmap state source: `roadmap.json`

--- a/docs/examples/full-design-blocked/README.md
+++ b/docs/examples/full-design-blocked/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.8.0`, `cc-do@1.6.2`, `cc-check@1.10.1`
+- Bound skills: `cc-roadmap@5.1.0`, `cc-plan@3.8.0`, `cc-do@1.6.2`, `cc-check@1.10.1`
 
 This example shows a requirement that **looked executable**, but `cc-check` correctly stopped it and sent it back to `cc-plan`.
 

--- a/docs/examples/full-design-blocked/ROADMAP.md
+++ b/docs/examples/full-design-blocked/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Roadmap Meta
 
 - Roadmap version: `roadmap.v2`
-- Skill version: `5.0.0`
+- Skill version: `5.1.0`
 - Status: `active`
 - Last updated: `2026-04-16`
 - Owner / decider: `product-owner`

--- a/docs/examples/full-design-blocked/roadmap.json
+++ b/docs/examples/full-design-blocked/roadmap.json
@@ -5,7 +5,7 @@
   },
   "meta": {
     "roadmapVersion": "roadmap.v2",
-    "skillVersion": "5.0.0",
+    "skillVersion": "5.1.0",
     "status": "active",
     "lastUpdated": "2026-04-19",
     "currentFocusStage": "Stage 2"

--- a/docs/examples/local-handoff/BACKLOG.md
+++ b/docs/examples/local-handoff/BACKLOG.md
@@ -5,7 +5,7 @@
 ## Backlog Meta
 
 - Roadmap version: `roadmap.v2`
-- Skill version: `5.0.0`
+- Skill version: `5.1.0`
 - Last synced: `2026-04-19`
 - Current focus stage: `Stage 2`
 - Roadmap state source: `roadmap.json`

--- a/docs/examples/local-handoff/README.md
+++ b/docs/examples/local-handoff/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.8.0`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
+- Bound skills: `cc-roadmap@5.1.0`, `cc-plan@3.8.0`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
 
 This example shows verified work that is **ready to move forward**, but `cc-act` still chooses `local-handoff`.
 

--- a/docs/examples/local-handoff/ROADMAP.md
+++ b/docs/examples/local-handoff/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Roadmap Meta
 
 - Roadmap version: `roadmap.v3`
-- Skill version: `5.0.0`
+- Skill version: `5.1.0`
 - Status: `active`
 - Last updated: `2026-04-16`
 - Owner / decider: `product-owner`

--- a/docs/examples/local-handoff/roadmap.json
+++ b/docs/examples/local-handoff/roadmap.json
@@ -5,7 +5,7 @@
   },
   "meta": {
     "roadmapVersion": "roadmap.v2",
-    "skillVersion": "5.0.0",
+    "skillVersion": "5.1.0",
     "status": "active",
     "lastUpdated": "2026-04-19",
     "currentFocusStage": "Stage 2"

--- a/docs/examples/pdca-loop/BACKLOG.md
+++ b/docs/examples/pdca-loop/BACKLOG.md
@@ -5,7 +5,7 @@
 ## Backlog Meta
 
 - Roadmap version: `roadmap.v1`
-- Skill version: `5.0.0`
+- Skill version: `5.1.0`
 - Last synced: `2026-04-19`
 - Current focus stage: `Stage 1`
 - Roadmap state source: `roadmap.json`

--- a/docs/examples/pdca-loop/README.md
+++ b/docs/examples/pdca-loop/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.0.0`, `cc-plan@3.8.0`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
+- Bound skills: `cc-roadmap@5.1.0`, `cc-plan@3.8.0`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
 
 This folder shows one minimal but complete `cc-roadmap -> cc-plan -> cc-do -> cc-check -> cc-act` loop.
 

--- a/docs/examples/pdca-loop/ROADMAP.md
+++ b/docs/examples/pdca-loop/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Roadmap Meta
 
 - Roadmap version: `roadmap.v1`
-- Skill version: `5.0.0`
+- Skill version: `5.1.0`
 - Status: `active`
 - Last updated: `2026-04-15`
 - Owner / decider: `product-owner`

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
@@ -9,7 +9,7 @@
   "sourceRoadmap": {
     "itemId": "RM-001",
     "roadmapVersion": "roadmap.v1",
-    "roadmapSkillVersion": "5.0.0",
+    "roadmapSkillVersion": "5.1.0",
     "sourceStage": "Stage 1",
     "successSignal": "Users can copy the invite link with one click",
     "killSignal": "The patch requires backend or permission changes",

--- a/docs/examples/pdca-loop/roadmap.json
+++ b/docs/examples/pdca-loop/roadmap.json
@@ -5,7 +5,7 @@
   },
   "meta": {
     "roadmapVersion": "roadmap.v1",
-    "skillVersion": "5.0.0",
+    "skillVersion": "5.1.0",
     "status": "active",
     "lastUpdated": "2026-04-19",
     "currentFocusStage": "Stage 1"

--- a/lib/skill-runtime/__tests__/archive-change.test.js
+++ b/lib/skill-runtime/__tests__/archive-change.test.js
@@ -1,0 +1,124 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { archiveChange, restoreChange, listArchived, getArchiveRoot } = require('../archive-change');
+
+function makeTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-devflow-archive-'));
+  const changesDir = path.join(repoRoot, 'devflow', 'changes');
+  fs.mkdirSync(changesDir, { recursive: true });
+  return repoRoot;
+}
+
+afterEach(() => {});
+
+describe('archiveChange', () => {
+  test('moves change directory to archive/YYYY-MM/', () => {
+    const repoRoot = makeTempRepo();
+    const changeDir = path.join(repoRoot, 'devflow', 'changes', 'REQ-001-feature');
+    fs.mkdirSync(changeDir, { recursive: true });
+    fs.writeFileSync(path.join(changeDir, 'proposal.md'), '# test');
+
+    const result = archiveChange(repoRoot, 'REQ-001-feature');
+    const month = new Date().toISOString().slice(0, 7);
+
+    expect(result.month).toBe(month);
+    expect(fs.existsSync(result.archived)).toBe(true);
+    expect(fs.existsSync(path.join(result.archived, 'proposal.md'))).toBe(true);
+    expect(fs.existsSync(changeDir)).toBe(false);
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test('throws when change directory does not exist', () => {
+    const repoRoot = makeTempRepo();
+
+    expect(() => archiveChange(repoRoot, 'REQ-999-nonexistent'))
+      .toThrow(/not found/);
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test('throws when archive target already exists', () => {
+    const repoRoot = makeTempRepo();
+    const changeDir = path.join(repoRoot, 'devflow', 'changes', 'REQ-001-dup');
+    fs.mkdirSync(changeDir, { recursive: true });
+
+    const month = new Date().toISOString().slice(0, 7);
+    const existingArchive = path.join(getArchiveRoot(repoRoot), month, 'REQ-001-dup');
+    fs.mkdirSync(existingArchive, { recursive: true });
+
+    expect(() => archiveChange(repoRoot, 'REQ-001-dup'))
+      .toThrow(/already exists/);
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+});
+
+describe('restoreChange', () => {
+  test('moves archived directory back to changes/', () => {
+    const repoRoot = makeTempRepo();
+    const archivedDir = path.join(repoRoot, 'devflow', 'changes', 'archive', '2026-04', 'REQ-002-restored');
+    fs.mkdirSync(archivedDir, { recursive: true });
+    fs.writeFileSync(path.join(archivedDir, 'tasks.md'), '- [ ] task');
+
+    const result = restoreChange(repoRoot, archivedDir);
+
+    expect(result.changeKey).toBe('REQ-002-restored');
+    expect(fs.existsSync(result.restored)).toBe(true);
+    expect(fs.existsSync(path.join(result.restored, 'tasks.md'))).toBe(true);
+    expect(fs.existsSync(archivedDir)).toBe(false);
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test('throws when archived directory does not exist', () => {
+    const repoRoot = makeTempRepo();
+
+    expect(() => restoreChange(repoRoot, '/tmp/nonexistent-archive-path'))
+      .toThrow(/not found/);
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test('throws when change already exists in active directory', () => {
+    const repoRoot = makeTempRepo();
+    const activeDir = path.join(repoRoot, 'devflow', 'changes', 'REQ-003-conflict');
+    fs.mkdirSync(activeDir, { recursive: true });
+
+    const archivedDir = path.join(repoRoot, 'devflow', 'changes', 'archive', '2026-03', 'REQ-003-conflict');
+    fs.mkdirSync(archivedDir, { recursive: true });
+
+    expect(() => restoreChange(repoRoot, archivedDir))
+      .toThrow(/already exists/);
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+});
+
+describe('listArchived', () => {
+  test('returns empty array when no archive exists', () => {
+    const repoRoot = makeTempRepo();
+    expect(listArchived(repoRoot)).toEqual([]);
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test('lists archived changes across months', () => {
+    const repoRoot = makeTempRepo();
+    const archiveRoot = getArchiveRoot(repoRoot);
+
+    fs.mkdirSync(path.join(archiveRoot, '2026-03', 'REQ-001-old'), { recursive: true });
+    fs.mkdirSync(path.join(archiveRoot, '2026-04', 'FIX-002-bugfix'), { recursive: true });
+    fs.mkdirSync(path.join(archiveRoot, '2026-04', 'REQ-003-another'), { recursive: true });
+
+    const items = listArchived(repoRoot);
+
+    expect(items).toHaveLength(3);
+    expect(items[0]).toEqual(expect.objectContaining({ month: '2026-03', changeKey: 'REQ-001-old' }));
+    expect(items[1]).toEqual(expect.objectContaining({ month: '2026-04', changeKey: 'FIX-002-bugfix' }));
+    expect(items[2]).toEqual(expect.objectContaining({ month: '2026-04', changeKey: 'REQ-003-another' }));
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+});

--- a/lib/skill-runtime/archive-change.js
+++ b/lib/skill-runtime/archive-change.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const { getChangesRoot } = require('./paths.js');
+
+function getArchiveRoot(repoRoot) {
+  return path.join(getChangesRoot(repoRoot), 'archive');
+}
+
+function archiveChange(repoRoot, changeKey) {
+  const changesRoot = getChangesRoot(repoRoot);
+  const changeDir = path.join(changesRoot, changeKey);
+
+  if (!fs.existsSync(changeDir) || !fs.statSync(changeDir).isDirectory()) {
+    throw new Error(`Change directory not found: ${changeDir}`);
+  }
+
+  const month = new Date().toISOString().slice(0, 7);
+  const archiveDir = path.join(getArchiveRoot(repoRoot), month);
+  fs.mkdirSync(archiveDir, { recursive: true });
+
+  const dest = path.join(archiveDir, changeKey);
+  if (fs.existsSync(dest)) {
+    throw new Error(`Archive target already exists: ${dest}`);
+  }
+
+  fs.renameSync(changeDir, dest);
+  return { archived: dest, month };
+}
+
+function restoreChange(repoRoot, archivedPath) {
+  if (!fs.existsSync(archivedPath) || !fs.statSync(archivedPath).isDirectory()) {
+    throw new Error(`Archived directory not found: ${archivedPath}`);
+  }
+
+  const changeKey = path.basename(archivedPath);
+  const changesRoot = getChangesRoot(repoRoot);
+  const dest = path.join(changesRoot, changeKey);
+
+  if (fs.existsSync(dest)) {
+    throw new Error(`Change already exists in active directory: ${dest}`);
+  }
+
+  fs.mkdirSync(changesRoot, { recursive: true });
+  fs.renameSync(archivedPath, dest);
+  return { restored: dest, changeKey };
+}
+
+function listArchived(repoRoot) {
+  const archiveRoot = getArchiveRoot(repoRoot);
+  if (!fs.existsSync(archiveRoot)) return [];
+
+  const results = [];
+  for (const month of fs.readdirSync(archiveRoot, { withFileTypes: true })) {
+    if (!month.isDirectory()) continue;
+    const monthDir = path.join(archiveRoot, month.name);
+    for (const entry of fs.readdirSync(monthDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      results.push({ month: month.name, changeKey: entry.name, path: path.join(monthDir, entry.name) });
+    }
+  }
+  return results;
+}
+
+module.exports = { archiveChange, restoreChange, listArchived, getArchiveRoot };

--- a/test/roadmap-tracking.test.js
+++ b/test/roadmap-tracking.test.js
@@ -149,10 +149,19 @@ describe('cc-roadmap tracking sync', () => {
           version: 3,
           meta: {
             roadmapVersion: 'roadmap.v2',
-            skillVersion: '5.0.0',
+            skillVersion: '5.1.0',
             status: 'active',
             lastUpdated: '2026-05-01',
             currentFocusStage: 'Stage 1'
+          },
+          context: {
+            projectDirectionMode: 'founder-business',
+            projectDirectionRationale: 'the roadmap is choosing a paid wedge',
+            directionQuestionsSelected: ['demand reality', 'narrowest paid wedge'],
+            directionQuestionsSkipped: ['long-term platform architecture'],
+            directionGuardrailsApplied: ['brand-neutral founder advice'],
+            planningPosture: 'startup',
+            evidenceMaturity: 'idea'
           },
           items: [
             {
@@ -231,6 +240,14 @@ describe('cc-roadmap tracking sync', () => {
       true
     );
     expect(renderedBacklog).toContain('- Roadmap state source: `roadmap.json`');
+    expect(renderedBacklog).toContain('## Project Direction Handoff');
+    expect(renderedBacklog).toContain('- Project direction mode: founder-business');
+    expect(renderedBacklog).toContain(
+      '- Direction-specific questions selected: demand reality, narrowest paid wedge'
+    );
+    expect(renderedBacklog).toContain(
+      '- Direction guardrails applied: brand-neutral founder advice'
+    );
     expect(renderedBacklog).toContain('| RM-010 | Generate roadmap views from state |');
 
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add a Project Direction Gate to `cc-roadmap` so roadmap sessions classify founder/business, internal, demo, OSS/research, learning, side-project, infrastructure, and recovery modes before selecting questions
- add brand-neutral founder guardrails that keep demand, status quo, user specificity, wedge, and observation checks while excluding promotional institution references
- carry direction handoff fields through `roadmap.json`, generated backlog projection, examples, and renderer tests

## Test plan
- [x] `npm test`
- [x] `npm run verify:publish`
- [x] `npm run adapt:check`
- [x] `npm run verify:examples`
- [x] `git diff --check`