### PR TITLE
feat(plan): 强制任务模板与状态脚本

### DIFF
--- a/.claude/skills/cc-do/CHANGELOG.md
+++ b/.claude/skills/cc-do/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CC-Do Skill Changelog
 
+## v1.6.3 - 2026-05-10
+
+- require task completion to go through `scripts/mark-task-complete.sh` instead of manual checkbox or manifest edits
+- add a ClaudeCode / Codex task status protocol so execution reads full task blocks and advances `currentTaskId` through scripts
+- document failure behavior when the completion script rejects missing checkpoint or review-gate evidence
+
 ## v1.6.2 - 2026-05-06
 
 - absorb the external TDD skill's execution details into native `cc-do`: spec-style test names, one logical behavior per Red, and public verification paths

--- a/.claude/skills/cc-do/SKILL.md
+++ b/.claude/skills/cc-do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-do
-version: 1.6.2
+version: 1.6.3
 description: Use when implementing planned tasks, resuming interrupted work, applying a frozen investigation handoff, or landing review feedback after cc-plan or cc-investigate.
 triggers:
   - 开始做 T003
@@ -44,6 +44,7 @@ entry_gate:
 exit_criteria:
   - The current task has red/green evidence, public-seam test quality evidence, review evidence, and a resumable checkpoint trail.
   - Red evidence proves one observable behavior through a public verification path; Green evidence shows only the minimal production change; Refactor evidence names the concrete smell removed or says why none was needed.
+  - The completed task was closed through `scripts/mark-task-complete.sh`; manual checkbox/status edits are not valid completion evidence.
   - Execution leaves the next verifier enough runtime truth to judge the task without chat memory.
   - The honest next step is cc-check or an explicit reroute.
 reroutes:
@@ -234,6 +235,27 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 13. 失败和阻塞都要留下恢复证据。
 14. 给 subagent 的输入必须包含：当前进度、当前任务全文、依赖状态、必读文件、验收标准、可信命令。
 15. 三次失败修补后必须先质疑调查合同或设计合同，而不是继续堆补丁。
+16. 完成任务后必须调用 `scripts/mark-task-complete.sh` 同步 `planning/task-manifest.json` 和 `planning/tasks.md`；禁止手工改 checkbox、status、currentTaskId 来冒充完成。
+17. 如果 `mark-task-complete.sh` 失败，说明 checkpoint、review gate 或任务依赖还没闭合；先修证据，再重跑脚本，不准绕过。
+
+## Task Status Protocol
+
+ClaudeCode / Codex 执行 `cc-do` 时必须把任务状态当成状态机，不是普通 Markdown TODO。
+
+1. 开始前用 `planning/task-manifest.json.currentTaskId` 或 ready-task 脚本确认当前任务。
+2. 执行时读取完整 task block，包含 Goal、TDD phase、Files、Read first、Verification、Evidence、test seam、mock boundary、minimality / refactor 字段。
+3. 完成验证和 review gate 后运行完成脚本：
+
+```bash
+SCRIPT_ROOT=".claude/skills/cc-do/scripts"
+if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then
+  SCRIPT_ROOT=".codex/skills/cc-do/scripts"
+fi
+bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task <task-id>
+```
+
+4. 脚本会先跑任务 gate，再同步 manifest、checkbox、`currentTaskId` 和整体状态。不要手动改这些字段。
+5. 如果任务不能完成，写 checkpoint / event / blocker；不要把失败任务标成完成。
 
 ## Exit Criteria
 

--- a/.claude/skills/cc-plan/CHANGELOG.md
+++ b/.claude/skills/cc-plan/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CC-Plan Skill Changelog
 
+## v3.8.2 - 2026-05-10
+
+- require `cc-plan` to generate executable tasks from the bundled task template instead of loose Markdown checklists
+- add a durable execution protocol for ClaudeCode and Codex so ready-task selection and task completion are script-driven
+- require task manifests to record template compliance and `mark-task-complete.sh` commands so task status is not hand-edited or forgotten
+
 ## v3.8.1 - 2026-05-09
 
 - add the AI Leverage Decision Lens before approach approval so plans must name the real user/operator, current workaround, human-vs-agent effort, complete-lake boundary, ocean boundary, scope recommendation, cost model, and boil-lake/sharp-wedge/needs-evidence/pivot verdict

--- a/.claude/skills/cc-plan/SKILL.md
+++ b/.claude/skills/cc-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-plan
-version: 3.8.1
+version: 3.8.2
 description: Use when a requirement, roadmap item, or bug needs scope clarification, design decisions, and executable task breakdown before coding starts.
 triggers:
   - 帮我规划这个需求
@@ -18,6 +18,8 @@ reads:
   - assets/TASKS_TEMPLATE.md
   - assets/TASK_MANIFEST_TEMPLATE.json
   - references/planning-contract.md
+  - ../cc-do/scripts/select-ready-tasks.sh
+  - ../cc-do/scripts/mark-task-complete.sh
   - ../cc-roadmap/scripts/locate-roadmap-item.sh
   - ../cc-roadmap/scripts/sync-roadmap-progress.sh
 writes:
@@ -43,6 +45,8 @@ entry_gate:
   - If the raw ask spans multiple independent subsystems, split it back into roadmap stages or separate REQ/FIX candidates before asking implementation details.
   - "For non-trivial designs, compare named option roles: minimal viable, ideal architecture, and optional hybrid. Do not default to smallest unless it best serves the goal."
   - Plan executable work as Red/Green/Refactor by default; identify the first failing test before any production implementation task, or write an explicit TDD exception with replacement evidence.
+  - Generate `planning/tasks.md` from `assets/TASKS_TEMPLATE.md` semantics, including every required task field, the execution protocol, and the exact task completion command; do not free-form a loose checklist.
+  - Generate `planning/task-manifest.json.executionProtocol` so ClaudeCode / Codex execution can select ready tasks and mark completion through scripts instead of hand-editing status.
   - For behavior changes, freeze the spec-style test name, one logical behavior, public verification path, and interface-testability decision before task split.
   - "Before approach approval, run the AI Leverage Decision Lens: real user/operator, status quo workaround, human-vs-agent effort, complete-lake boundary, ocean boundary, scope recommendation, and boil-lake/sharp-wedge/needs-evidence/pivot verdict."
   - Before approach approval, decide whether external best-practice validation could materially change the plan; if yes, ask the user through the Decision Question Protocol before any web or external lookup.
@@ -53,6 +57,8 @@ entry_gate:
 exit_criteria:
   - planning/design.md captures the approved solution, PRD-grade requirement brief, boundaries, review conclusions, and execution edge cases.
   - planning/tasks.md, planning/task-manifest.json, and change-meta.json are explicit enough that cc-do can continue without chat memory.
+  - planning/tasks.md contains the task-template compliance section and script-based completion protocol, and every task block includes its completion command.
+  - task-manifest.json records `executionProtocol.templateCompliance.required = true` and a `completion.commandTemplate` that calls `mark-task-complete.sh`.
   - The task breakdown preserves test-first execution; failing-test tasks precede implementation tasks, refactor checkpoints are visible, and any TDD exception is justified.
   - "Testability decisions make the public seam natural: small interface, deep implementation, injected boundary dependencies, returned results where practical, and boundary mocks only where the system genuinely leaves the repo."
   - AI Leverage Decision Lens is recorded in planning/design.md and task-manifest.json.planningMeta.aiLeverageDecisionLens before executable tasks are generated.
@@ -181,10 +187,11 @@ bash .claude/skills/cc-plan/scripts/next-change-key.sh --prefix REQ --descriptio
    - 记录 source handoff、PRD-grade requirement brief、问题定义、备选方案、批准方案、设计决策、review gate、执行边界
 2. `planning/tasks.md`
    - 只保留可执行任务和执行 handoff
-   - 顶部写清 frozen decisions、read first、commands to trust、TDD plan、并行边界
+   - 顶部写清 frozen decisions、read first、commands to trust、TDD plan、并行边界、任务模板遵循规则、任务完成脚本
 3. `planning/task-manifest.json`
    - 从 `planning/tasks.md` 编译出的机器真相源
    - 只服务执行与调度，不再承担人类阅读的叙事职责
+   - 必须包含 `executionProtocol`：模板字段完整性、ready-task 选择命令、任务完成命令、禁止手工修改状态
 4. `change-meta.json`
    - 绑定 roadmap item、primary capability、secondary capabilities、expected spec delta、spec sync status
    - 作为 `cc-do`、`cc-check`、`cc-act` 的 capability 机器真相源
@@ -198,6 +205,39 @@ bash .claude/skills/cc-plan/scripts/next-change-key.sh --prefix REQ --descriptio
 - `handoff/resume-index.md`
 
 这些信息如果仍然需要，必须并入 `planning/design.md` 或 `planning/tasks.md`，而不是再拆新文件。
+
+## ClaudeCode / Codex Execution Compliance
+
+`cc-plan` 不能只产出“看起来像任务”的列表。它必须把执行者遵循任务模板和状态脚本的能力写进 durable artifacts，尤其是 ClaudeCode 这类容易把 Markdown checklist 当普通 TODO 的宿主。
+
+生成 `planning/tasks.md` 时必须包含一个清晰的 `Execution Protocol` 区块，写明：
+
+1. 执行者必须逐个读取完整 task block，不得只看标题或 checkbox。
+2. 当前可做任务由 `planning/task-manifest.json.currentTaskId` 和 ready-task 脚本决定，不得凭聊天记忆挑任务。
+3. 每个 task 必须保留模板字段：Goal、TDD phase、Files、Read first、Verification、Evidence、test seam、mock boundary、green minimality 或 refactor candidates。
+4. 任务完成后必须调用 `mark-task-complete.sh` 同步 `planning/task-manifest.json` 和 `planning/tasks.md`；禁止手工把 checkbox 改成 `[x]`，禁止只改 manifest，禁止完成后不标记。
+5. 如果完成脚本失败，不能手改绕过；先修复缺失 gate、checkpoint 或 review evidence，再重跑脚本。
+
+生成 `planning/task-manifest.json` 时必须写入：
+
+- `executionProtocol.templateCompliance.required = true`
+- `executionProtocol.templateCompliance.sourceTemplate = "assets/TASKS_TEMPLATE.md"`
+- `executionProtocol.selection.commandTemplate`
+- `executionProtocol.completion.commandTemplate`
+- `executionProtocol.completion.manualStatusEdit = "forbidden"`
+- 每个 `tasks[]` 的 `completion` 字段，至少包含 command、requiredBeforeCompletion、forbiddenShortcuts。
+
+脚本路径必须支持 ClaudeCode 和 Codex mirror：
+
+```bash
+SCRIPT_ROOT=".claude/skills/cc-do/scripts"
+if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then
+  SCRIPT_ROOT=".codex/skills/cc-do/scripts"
+fi
+bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task <task-id>
+```
+
+这段命令要出现在 `planning/tasks.md` 的 `Execution Protocol` 和每个 task 的 `Completion` 字段里。执行者不应该再问“怎么标记完成”。
 
 ## Entry Gate
 
@@ -503,7 +543,9 @@ STOP: wait for the user answer before continuing.
 - `planning/design.md` 必须说明接口为什么可测：依赖注入、可断言返回、系统边界 adapter 形状、以及为什么测试不需要 mock 内部协作者
 - `planning/design.md` 必须暴露 assumptions preview、ambiguity gate、source trust boundary、external best-practice validation、external conflict buckets 和 bounded review loop；这些是阻止模糊需求进入执行期的合同，不是可选美化项
 - `planning/tasks.md` 只保留能直接执行的任务和 handoff，不再承载重复背景介绍；行为变更默认拆成 tracer bullet 形式的 `[TEST] -> [IMPL] -> [REFACTOR]`，且 Red task 明确 spec-style test name、单一行为、公共 seam、行为断言、mock 边界和反馈循环
-- `planning/task-manifest.json` 是 `cc-do` 的真相源，要写清 `planningMeta.requirementBrief`、`planningMeta.ambiguityGate`、`planningMeta.reviewLoop`、`sourceEvidence[]`、`dependsOn`、`tddPhase`、`verticalSlice`、test seam、public verification path、allowed mocks、feedback loop、minimality guard、refactor candidates、并行资格、触点、验证命令，以及继承了哪版 roadmap / design / spec
+- `planning/tasks.md` 必须把 `assets/TASKS_TEMPLATE.md` 的任务字段实例化到每个 task；不能只生成标题清单，也不能让 ClaudeCode / Codex 靠猜测补字段
+- `planning/tasks.md` 必须写出任务完成脚本，要求执行者完成每个 task 后调用 `mark-task-complete.sh`，禁止手动勾选或漏标
+- `planning/task-manifest.json` 是 `cc-do` 的真相源，要写清 `planningMeta.requirementBrief`、`planningMeta.ambiguityGate`、`planningMeta.reviewLoop`、`executionProtocol`、`sourceEvidence[]`、`dependsOn`、`tddPhase`、`verticalSlice`、test seam、public verification path、allowed mocks、feedback loop、minimality guard、refactor candidates、completion command、并行资格、触点、验证命令，以及继承了哪版 roadmap / design / spec
 - `change-meta.json` 是 capability 真相源，要写清这次 change 准备如何改变长期 spec
 - roadmap sync 不是聊天提醒：如果 source RM 存在，必须更新 `devflow/roadmap.json` 并重新生成 `devflow/ROADMAP.md` / `devflow/BACKLOG.md`；如果不存在，必须记录 no-op reason
 - 看完第一屏，执行者就知道这次属于 `tiny-design` 还是 `full-design`，以及为什么

--- a/.claude/skills/cc-plan/assets/TASKS_TEMPLATE.md
+++ b/.claude/skills/cc-plan/assets/TASKS_TEMPLATE.md
@@ -49,6 +49,25 @@
 
 > 顶部 handoff 只保留执行者必须知道的现实，不重复讲背景故事。
 
+## Execution Protocol
+
+ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合同，而不是普通 TODO 列表。
+
+- Template source: `assets/TASKS_TEMPLATE.md`
+- Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
+- Task block rule: read the full task block before coding; title-only execution is invalid.
+- Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
+- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+
+```bash
+SCRIPT_ROOT=".claude/skills/cc-do/scripts"
+if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then
+  SCRIPT_ROOT=".codex/skills/cc-do/scripts"
+fi
+bash "$SCRIPT_ROOT/select-ready-tasks.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json
+bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task <task-id>
+```
+
 ## Implementation Surface Map
 
 | Surface | Responsibility | Tasks | Coupling risk |
@@ -74,6 +93,7 @@
   Read first: `design.md`, `tasks.md`
   Verification: `npm test -- path/to/test`
   Evidence: failing output
+  Completion: after failing evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T001`; do not hand-edit status.
   Coverage: unit / integration / e2e / eval; regression: yes / no
   Spec-style test name: 测试名像规格说明，描述可观察行为
   One logical behavior: yes / no
@@ -92,6 +112,7 @@
   Read first: `design.md`, `path/to/test`
   Verification: `npm test -- path/to/test`
   Evidence: passing output + checkpoint
+  Completion: after green evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T002`; do not hand-edit status.
   Green minimality guard: 只写当前红灯要求的最小实现，不预铺未来行为、分支或 API
   Vertical slice: Slice 1
   Ready when: T001 已经见红，且当前 touched files 不和其他并行任务冲突
@@ -105,6 +126,7 @@
   Read first: `design.md`, `tasks.md`
   Verification: `npm test -- path/to/other.test`
   Evidence: failing output
+  Completion: after failing evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T003`; do not hand-edit status.
   Coverage: unit / integration / e2e / eval; regression: yes / no
   Spec-style test name: 测试名像规格说明，描述可观察行为
   One logical behavior: yes / no
@@ -123,6 +145,7 @@
   Read first: `design.md`, `path/to/other.test`
   Verification: `npm test -- path/to/other.test`
   Evidence: passing output + review notes
+  Completion: after green evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T004`; do not hand-edit status.
   Green minimality guard: 只写当前红灯要求的最小实现，不预铺未来行为、分支或 API
   Vertical slice: Slice 2
   Ready when: T003 已经见红，且文件触点与其他 `[P]` 任务不冲突
@@ -136,6 +159,7 @@
   Read first: `design.md`, green test outputs
   Verification: `npm test -- path/to/test path/to/other.test`
   Evidence: refactor diff + repeated green output
+  Completion: after refactor evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T005`; do not hand-edit status.
   Refactor candidates: duplication / long method / shallow module / feature envy / primitive obsession / naming / >3 nesting / newly exposed old code smell
   Ready when: 对应 Red/Green 任务都已完成，且清理不会扩大 scope
 
@@ -146,6 +170,7 @@
   Read first: `tasks.md`, `task-manifest.json`
   Verification: `npm test && npm run lint`
   Evidence: gate output
+  Completion: after gate evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T006`; do not hand-edit status.
   Ready when: 当前 requirement 的实现任务都已收口
 
 > `[P]` 只表示“依赖满足后有资格并行”，不表示可以无脑同时开发。
@@ -167,3 +192,4 @@
 - Refactor task 要清理哪些具体坏味道，且只在相关测试已绿后执行
 - 测试是否会在内部重构后继续成立，而不是绑定私有函数、调用次数或临时结构
 - 它属于哪个 tracer bullet 垂直切片，完成后哪个可观察行为被证明
+- 它完成后要运行哪条 `mark-task-complete.sh` 命令，以及为什么不能手工改状态

--- a/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
+++ b/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
@@ -28,7 +28,7 @@
     ]
   },
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.1",
+    "reqPlanSkillVersion": "3.8.2",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-15T12:00:00.000Z",
     "approvedBy": "user",
@@ -130,6 +130,40 @@
         "status": "answered"
       }
     ]
+  },
+  "executionProtocol": {
+    "templateCompliance": {
+      "required": true,
+      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
+      "taskBlockMustInclude": [
+        "Goal",
+        "TDD phase",
+        "Files",
+        "Read first",
+        "Verification",
+        "Evidence",
+        "Test seam",
+        "Public verification path",
+        "Allowed mocks",
+        "Completion"
+      ],
+      "titleOnlyTasks": "forbidden"
+    },
+    "selection": {
+      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT/select-ready-tasks.sh\" --manifest devflow/changes/<change-key>/planning/task-manifest.json"
+    },
+    "completion": {
+      "manualStatusEdit": "forbidden",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT/mark-task-complete.sh\" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task <task-id>",
+      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
+      "updates": [
+        "planning/task-manifest.json.tasks[].status",
+        "planning/task-manifest.json.currentTaskId",
+        "planning/task-manifest.json.status",
+        "planning/tasks.md checkbox"
+      ]
+    }
   },
   "sourceEvidence": [
     {
@@ -246,6 +280,20 @@
       "greenMinimality": {
         "guard": "Implement only the code needed to pass this Red behavior",
         "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT/mark-task-complete.sh\" --manifest devflow/changes/REQ-XXX-short-name/planning/task-manifest.json --tasks devflow/changes/REQ-XXX-short-name/planning/tasks.md --task T001",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
       },
       "refactorCandidates": [
         "duplication",

--- a/.claude/skills/cc-plan/references/planning-contract.md
+++ b/.claude/skills/cc-plan/references/planning-contract.md
@@ -73,10 +73,21 @@
 - 涉及文件
 - 验证方式
 - 完成证据
+- Completion command：调用 `mark-task-complete.sh`，同步 `planning/task-manifest.json` 与 `planning/tasks.md`
+- Forbidden shortcuts：禁止手工改 checkbox、manifest status 或 `currentTaskId`
 
 行为变更任务必须先有 `[TEST]` 红灯任务，再有 `[IMPL]` 绿灯任务，最后有 `[REFACTOR]` 或明确 refactor checkpoint。纯文档、纯配置、纯生成文件、throwaway prototype 可以例外，但必须写明原因、风险和替代验证。
 不要把计划拆成水平层：一批测试、一批服务、一批 UI。每个切片完成后都应该能证明一个真实行为。
 也不要把一批 Red 一次性写完再批量实现。每条 tracer bullet 只证明一个可观察行为，Green 只做当前红灯要求的最小实现；下一条 Red 可以吸收上一轮学到的事实，但不能越过冻结边界。
+
+## Execution Protocol Fields
+
+`planning/tasks.md` 必须有 `Execution Protocol` 区块，`planning/task-manifest.json` 必须有 `executionProtocol` 对象。它们共同约束 ClaudeCode / Codex：
+
+- task 选择来自 `currentTaskId` 或 `select-ready-tasks.sh`
+- 每个 task 必须按模板字段完整展开，不能退化成标题清单
+- 完成 task 必须调用 `mark-task-complete.sh`
+- 脚本失败时修 evidence / checkpoint / review gate 后重跑，禁止手工绕过
 
 ## Decision Question Fields
 

--- a/.claude/skills/cc-simplify/CHANGELOG.md
+++ b/.claude/skills/cc-simplify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CC-Simplify Skill Changelog
 
+## v1.4.1 - 2026-05-10
+
+- make `cc-simplify` itself the explicit trigger for automatic read-only subagent review in ClaudeCode and Codex environments
+- prefer ClaudeCode `Task` / subAgent support or Codex built-in `explorer` / `default` agents without requiring an extra user prompt
+- require a truthful fallback report when the host does not expose any subagent tool, instead of pretending subagents ran
+
 ## v1.4.0 - 2026-04-28
 
 - add deep-module architecture review checks for shallow wrappers, hypothetical seams, and complexity that should move behind a smaller interface

--- a/.claude/skills/cc-simplify/SKILL.md
+++ b/.claude/skills/cc-simplify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cc-simplify
-version: 1.4.0
-description: "Use when changed code needs a Codex-native simplification pass for scope drift, reuse, code quality, efficiency, test quality, and confidence-gated smell fixes before cc-check or cc-act."
+version: 1.4.1
+description: "Use when changed code needs an automatic subagent-backed simplification pass for scope drift, reuse, code quality, efficiency, test quality, and confidence-gated smell fixes before cc-check or cc-act."
 ---
 
 # CC-Simplify
@@ -35,20 +35,31 @@ ONLY FIX CONFIRMED SMELLS. DO NOT BEAUTIFY BY GUESS.
 3. 如果变更跨多个互不相关模块，先按模块分组；不要让一个 cleanup pass 变成大扫除。
 4. 只审当前 diff 新增或本次改动扩大后的坏味道。历史债只在它阻挡当前交付或被本次 diff 放大时进入清理范围。
 
-## Phase 2: Codex 智能体评审
+## Phase 2: 自动子智能体评审
 
-如果当前环境支持 Codex 多智能体，并且用户已经明确触发 `cc-simplify` 或要求并行评审，可以构建只读评审智能体。
+触发 `cc-simplify` 本身就构成用户对子智能体 / subAgent 评审的明确授权。不要要求用户在 `[$cc-simplify]` 之外再补一句“请开启子智能体”。
+
+只要当前宿主支持子智能体，必须自动启动只读评审智能体；主线程只负责汇总、验证 finding、实际修复和最终验证。
 
 ### 调度原则
 
-- Codex 中优先使用 `spawn_agent(agent_type="explorer")` 创建只读评审智能体。
-- 如果当前环境没有 `explorer`，使用默认智能体也必须在 prompt 里写明：只读审查，不编辑文件。
+- ClaudeCode 环境：使用可用的 `Task` / subAgent 机制自动创建只读评审 subAgent。
+- Codex App / Codex 工具环境：优先使用内置 `explorer` 子智能体做只读评审；不要假设 ClaudeCode 的 `Task` / `subAgent` 语义存在。
+- 在暴露 `spawn_agent` 工具的 Codex 环境里，使用 `spawn_agent(agent_type="explorer", fork_context=false, ...)`；如果没有 `explorer`，使用 `default` 也必须在 prompt 里写明：只读审查，不编辑文件。
+- `cc-simplify` 的触发就是对子智能体的明确请求；不要再等待用户二次授权。
+- 不依赖 repo-local `.codex/agents/*.toml` 自定义 agent 名称来完成核心流程。自定义 agent 可以作为增强，但主流程必须能依赖 Codex 内置 `explorer` / `default` 或宿主内置 subAgent 机制。
 - 只把只读评审交给智能体；主线程负责最终判断和实际编辑。
 - 每个智能体拿到同一份完整 diff、相关任务/设计/spec 路径、当前 repo 根目录。
 - 智能体不能改文件，只输出结构化 findings。
-- 如果没有多智能体能力，主线程按同样清单顺序执行。
-- 小 diff 不强制开智能体：少于约 50 行且只触碰单一文件时，主线程执行同一清单即可。
+- 如果当前运行时没有子智能体工具，或工具调用被上层策略禁止，主线程按同样清单顺序执行，并在报告里写 `Agents used: no (subagent tool unavailable)`；不要伪造子智能体结果。
+- 小 diff 也要尝试启动子智能体；如果资源或宿主限制不适合三路并行，至少启动一个合并维度的只读 reviewer。
 - 条件 specialist 只在对应 scope 出现时启用；不要为了“完整”启动无关评审。
+
+默认调度：
+
+- 大 diff / 多文件 diff：启动 Agent A、Agent B、Agent C 三个只读评审智能体。
+- 小 diff / 单文件 diff：至少启动一个 combined reviewer，覆盖 A/B/C 三组检查。
+- 命中 security / api-contract / release / frontend-performance 时，再启动对应 specialist；如果 specialist 发现 `critical`，再启动 Red Team 只读复查。
 
 智能体 prompt 必须自包含：
 

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -1,10 +1,10 @@
 {
-  "updatedAt": "2026-05-09",
+  "updatedAt": "2026-05-10",
   "skills": {
     "cc-roadmap": "5.2.0",
-    "cc-plan": "3.8.1",
+    "cc-plan": "3.8.2",
     "cc-investigate": "1.3.0",
-    "cc-do": "1.6.2",
+    "cc-do": "1.6.3",
     "cc-review": "1.0.0",
     "cc-check": "1.10.1",
     "cc-act": "1.8.2",

--- a/docs/examples/full-design-blocked/README.md
+++ b/docs/examples/full-design-blocked/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.1`, `cc-do@1.6.2`, `cc-check@1.10.1`
+- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.2`, `cc-do@1.6.3`, `cc-check@1.10.1`
 
 This example shows a requirement that **looked executable**, but `cc-check` correctly stopped it and sent it back to `cc-plan`.
 

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/design.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-002.v2`
 - Design version: `design.v2`
-- CC-Plan skill version: `3.8.1`
+- CC-Plan skill version: `3.8.2`
 - Requirement ID: `REQ-002`
 - Design mode: `full-design`
 - Why not `tiny-design`: the feature crosses import parsing, invite rules, billing limits, duplicate handling, and audit logging

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
@@ -6,7 +6,7 @@
   "requirementId": "REQ-002",
   "requirementVersion": "REQ-002.v2",
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.1",
+    "reqPlanSkillVersion": "3.8.2",
     "designVersion": "design.v2",
     "approvedAt": null,
     "approvedBy": null,

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
@@ -245,7 +245,61 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "red",
+      "verticalSlice": "Slice 1",
+      "testSeam": {
+        "entry": "bulk invite rules and admin upload UI behavior",
+        "behaviorAsserted": "dangerous row outcomes are reproduced as explicit failing tests",
+        "specStyleTestName": "dangerous row outcomes are reproduced as explicit failing tests",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the bulk invite rule and admin panel tests through their public flows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": "Fails before the behavior exists"
+      },
+      "allowedMocks": [
+        "file upload boundary",
+        "billing / seat limit boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T001",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T002",
@@ -297,7 +351,61 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "green",
+      "verticalSlice": "Slice 2",
+      "testSeam": {
+        "entry": "bulk invite rules and admin upload UI behavior",
+        "behaviorAsserted": "bulk invite rows receive deterministic initial states",
+        "specStyleTestName": "bulk invite rows receive deterministic initial states",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the bulk invite rule and admin panel tests through their public flows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "file upload boundary",
+        "billing / seat limit boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Implement only the code needed to pass the current red behavior",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T002",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T003",
@@ -348,7 +456,61 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "red",
+      "verticalSlice": "Slice 3",
+      "testSeam": {
+        "entry": "bulk invite rules and admin upload UI behavior",
+        "behaviorAsserted": "mixed row outcomes are visible as UI failures before implementation",
+        "specStyleTestName": "mixed row outcomes are visible as UI failures before implementation",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the bulk invite rule and admin panel tests through their public flows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": "Fails before the behavior exists"
+      },
+      "allowedMocks": [
+        "file upload boundary",
+        "billing / seat limit boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T003",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T004",
@@ -400,7 +562,61 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "green",
+      "verticalSlice": "Slice 3",
+      "testSeam": {
+        "entry": "bulk invite rules and admin upload UI behavior",
+        "behaviorAsserted": "admins can see accepted, skipped, and rejected rows in the panel",
+        "specStyleTestName": "admins can see accepted, skipped, and rejected rows in the panel",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the bulk invite rule and admin panel tests through their public flows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "file upload boundary",
+        "billing / seat limit boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Implement only the code needed to pass the current red behavior",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T004",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T005",
@@ -456,12 +672,100 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "evidence",
+      "verticalSlice": "Slice 3",
+      "testSeam": {
+        "entry": "bulk invite rules and admin upload UI behavior",
+        "behaviorAsserted": "fresh verification evidence exists for cc-check",
+        "specStyleTestName": "fresh verification evidence exists for cc-check",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the bulk invite rule and admin panel tests through their public flows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "file upload boundary",
+        "billing / seat limit boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T005",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     }
   ],
   "metadata": {
     "source": "tasks.md",
     "generatedBy": "docs-example",
     "planVersion": 1
+  },
+  "executionProtocol": {
+    "templateCompliance": {
+      "required": true,
+      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
+      "taskBlockMustInclude": [
+        "Goal",
+        "TDD phase",
+        "Files",
+        "Read first",
+        "Verification",
+        "Evidence",
+        "Test seam",
+        "Public verification path",
+        "Allowed mocks",
+        "Completion"
+      ],
+      "titleOnlyTasks": "forbidden"
+    },
+    "selection": {
+      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/select-ready-tasks.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json"
+    },
+    "completion": {
+      "manualStatusEdit": "forbidden",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task <task-id>",
+      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
+      "updates": [
+        "planning/task-manifest.json.tasks[].status",
+        "planning/task-manifest.json.currentTaskId",
+        "planning/task-manifest.json.status",
+        "planning/tasks.md checkbox"
+      ]
+    }
   }
 }

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
@@ -37,50 +37,94 @@
   - audit row-result contract
 - Parallel boundaries: no parallel execution until row-outcome semantics are frozen
 
+## Execution Protocol
+
+ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合同，而不是普通 TODO 列表。
+
+- Template source: `assets/TASKS_TEMPLATE.md`
+- Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
+- Task block rule: read the full task block before coding; title-only execution is invalid.
+- Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
+- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+
+```bash
+SCRIPT_ROOT=".claude/skills/cc-do/scripts"
+if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then
+  SCRIPT_ROOT=".codex/skills/cc-do/scripts"
+fi
+bash "$SCRIPT_ROOT/select-ready-tasks.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
+bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task <task-id>
+```
+
 ## Phase 1: Rule Matrix
 
 - [x] T001 [TEST] Add failing tests for duplicate and over-limit row outcomes (dependsOn:none) `src/invite/bulk-import.test.ts`
   Goal: 先把最危险的 bulk invite 行为变成红灯。
+  TDD phase: red
   Files: `src/invite/bulk-import.test.ts`
   Read first: `design.md`, `src/invite/bulk-import.ts`
   Verification: `npm test -- src/invite/bulk-import.test.ts`
   Evidence: failing output
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T001`; do not hand-edit status.
+  Test seam: bulk invite rules and admin upload UI behavior
+  Public verification path: Run the bulk invite rule and admin panel tests through their public flows
+  Allowed mocks: file upload boundary / billing / seat limit boundary
   Ready when: 当前规则文件已经可定位
 
 - [x] T002 [IMPL] Implement the initial bulk invite row classification (dependsOn:T001) `src/invite/bulk-import.ts`
   Goal: 给 duplicate / over-limit 行为一个最小实现。
+  TDD phase: green
   Files: `src/invite/bulk-import.ts`
   Read first: `design.md`, `src/invite/bulk-import.test.ts`
   Verification: `npm test -- src/invite/bulk-import.test.ts`
   Evidence: passing output + checkpoint
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T002`; do not hand-edit status.
+  Test seam: bulk invite rules and admin upload UI behavior
+  Public verification path: Run the bulk invite rule and admin panel tests through their public flows
+  Allowed mocks: file upload boundary / billing / seat limit boundary
   Ready when: T001 已见红
 
 ## Phase 2: Surface Integration
 
 - [x] T003 [TEST] Add failing admin panel tests for mixed CSV results (dependsOn:T002) `src/admin/BulkInvitePanel.test.tsx`
   Goal: 在 UI 层看到 mixed row outcomes 的真实表现。
+  TDD phase: red
   Files: `src/admin/BulkInvitePanel.test.tsx`
   Read first: `design.md`, `src/admin/BulkInvitePanel.tsx`
   Verification: `npm test -- src/admin/BulkInvitePanel.test.tsx`
   Evidence: failing output
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T003`; do not hand-edit status.
+  Test seam: bulk invite rules and admin upload UI behavior
+  Public verification path: Run the bulk invite rule and admin panel tests through their public flows
+  Allowed mocks: file upload boundary / billing / seat limit boundary
   Ready when: T002 已完成
 
 - [x] T004 [IMPL] Render bulk invite results in the admin panel (dependsOn:T003) `src/admin/BulkInvitePanel.tsx`
   Goal: 把 row outcomes 接进管理界面。
+  TDD phase: green
   Files: `src/admin/BulkInvitePanel.tsx`
   Read first: `design.md`, `src/admin/BulkInvitePanel.test.tsx`
   Verification: `npm test -- src/admin/BulkInvitePanel.test.tsx`
   Evidence: passing output + review notes
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T004`; do not hand-edit status.
+  Test seam: bulk invite rules and admin upload UI behavior
+  Public verification path: Run the bulk invite rule and admin panel tests through their public flows
+  Allowed mocks: file upload boundary / billing / seat limit boundary
   Ready when: T003 已见红
 
 ## Phase 3: Verification
 
 - [x] T005 Run mixed-surface checks and gather review evidence (dependsOn:T004) `bulk invite quality gates`
   Goal: 为 `cc-check` 准备 bulk invite 的新鲜证据。
+  TDD phase: evidence
   Files: `src/admin/BulkInvitePanel.tsx`, `src/invite/bulk-import.ts`
   Read first: `tasks.md`, `task-manifest.json`
   Verification:
   - `npm test -- src/invite/bulk-import.test.ts`
   - `npm test -- src/admin/BulkInvitePanel.test.tsx`
   Evidence: passing output + review notes
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T005`; do not hand-edit status.
+  Test seam: bulk invite rules and admin upload UI behavior
+  Public verification path: Run the bulk invite rule and admin panel tests through their public flows
+  Allowed mocks: file upload boundary / billing / seat limit boundary
   Ready when: T004 已完成

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-002.v2`
 - Design version: `design.v2`
-- CC-Plan skill version: `3.8.1`
+- CC-Plan skill version: `3.8.2`
 - Source roadmap item: `RM-010`
 - Source roadmap version: `roadmap.v2`
 

--- a/docs/examples/local-handoff/README.md
+++ b/docs/examples/local-handoff/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.1`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
+- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.2`, `cc-do@1.6.3`, `cc-check@1.10.1`, `cc-act@1.8.2`
 
 This example shows verified work that is **ready to move forward**, but `cc-act` still chooses `local-handoff`.
 

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/design.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-003.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.1`
+- CC-Plan skill version: `3.8.2`
 - Requirement ID: `REQ-003`
 - Design mode: `tiny-design`
 - Why this stays `tiny-design`: the patch adds one export action inside the existing admin audit UI without changing data contracts

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
@@ -6,7 +6,7 @@
   "requirementId": "REQ-003",
   "requirementVersion": "REQ-003.v1",
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.1",
+    "reqPlanSkillVersion": "3.8.2",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-16T13:10:00.000Z",
     "approvedBy": "user",

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
@@ -163,7 +163,60 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "red",
+      "verticalSlice": "Slice 1",
+      "testSeam": {
+        "entry": "admin audit panel UI behavior",
+        "behaviorAsserted": "the missing download action is reproduced as a failing test",
+        "specStyleTestName": "the missing download action is reproduced as a failing test",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the audit summary panel test and observe CSV export through visible rows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": "Fails before the behavior exists"
+      },
+      "allowedMocks": [
+        "download / blob boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T001",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T002",
@@ -215,7 +268,60 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "green",
+      "verticalSlice": "Slice 2",
+      "testSeam": {
+        "entry": "admin audit panel UI behavior",
+        "behaviorAsserted": "admins can trigger a CSV download from the existing summary panel",
+        "specStyleTestName": "admins can trigger a CSV download from the existing summary panel",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the audit summary panel test and observe CSV export through visible rows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "download / blob boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Implement only the code needed to pass the current red behavior",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T002",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T003",
@@ -271,12 +377,99 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "evidence",
+      "verticalSlice": "Slice 3",
+      "testSeam": {
+        "entry": "admin audit panel UI behavior",
+        "behaviorAsserted": "fresh verification evidence exists for local handoff",
+        "specStyleTestName": "fresh verification evidence exists for local handoff",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the audit summary panel test and observe CSV export through visible rows",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "download / blob boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T003",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     }
   ],
   "metadata": {
     "source": "tasks.md",
     "generatedBy": "docs-example",
     "planVersion": 1
+  },
+  "executionProtocol": {
+    "templateCompliance": {
+      "required": true,
+      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
+      "taskBlockMustInclude": [
+        "Goal",
+        "TDD phase",
+        "Files",
+        "Read first",
+        "Verification",
+        "Evidence",
+        "Test seam",
+        "Public verification path",
+        "Allowed mocks",
+        "Completion"
+      ],
+      "titleOnlyTasks": "forbidden"
+    },
+    "selection": {
+      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/select-ready-tasks.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json"
+    },
+    "completion": {
+      "manualStatusEdit": "forbidden",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task <task-id>",
+      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
+      "updates": [
+        "planning/task-manifest.json.tasks[].status",
+        "planning/task-manifest.json.currentTaskId",
+        "planning/task-manifest.json.status",
+        "planning/tasks.md checkbox"
+      ]
+    }
   }
 }

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
@@ -36,32 +36,66 @@
   - panel placement
 - Parallel boundaries: none
 
+## Execution Protocol
+
+ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合同，而不是普通 TODO 列表。
+
+- Template source: `assets/TASKS_TEMPLATE.md`
+- Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
+- Task block rule: read the full task block before coding; title-only execution is invalid.
+- Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
+- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+
+```bash
+SCRIPT_ROOT=".claude/skills/cc-do/scripts"
+if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then
+  SCRIPT_ROOT=".codex/skills/cc-do/scripts"
+fi
+bash "$SCRIPT_ROOT/select-ready-tasks.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
+bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task <task-id>
+```
+
 ## Phase 1: Foundation
 
 - [x] T001 [TEST] Add a failing test for the missing download action (dependsOn:none) `src/admin/AuditSummaryPanel.test.tsx`
   Goal: 证明现在还没有可下载的 summary export。
+  TDD phase: red
   Files: `src/admin/AuditSummaryPanel.test.tsx`
   Read first: `design.md`, `src/admin/AuditSummaryPanel.tsx`
   Verification: `npm test -- src/admin/AuditSummaryPanel.test.tsx`
   Evidence: failing output
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T001`; do not hand-edit status.
+  Test seam: admin audit panel UI behavior
+  Public verification path: Run the audit summary panel test and observe CSV export through visible rows
+  Allowed mocks: download / blob boundary
   Ready when: 当前 audit summary test 已可运行
 
 - [x] T002 [IMPL] Add the download summary action (dependsOn:T001) `src/admin/AuditSummaryPanel.tsx`
   Goal: 用最小实现让 summary export 真的可用。
+  TDD phase: green
   Files: `src/admin/AuditSummaryPanel.tsx`
   Read first: `design.md`, `src/admin/AuditSummaryPanel.test.tsx`
   Verification: `npm test -- src/admin/AuditSummaryPanel.test.tsx`
   Evidence: passing output + checkpoint
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T002`; do not hand-edit status.
+  Test seam: admin audit panel UI behavior
+  Public verification path: Run the audit summary panel test and observe CSV export through visible rows
+  Allowed mocks: download / blob boundary
   Ready when: T001 已见红
 
 ## Phase 2: Verify
 
 - [x] T003 Run targeted checks and collect handoff evidence (dependsOn:T002) `audit summary quality gates`
   Goal: 为 `cc-check` 和 `cc-act` 留下这次导出改动的真实证据。
+  TDD phase: evidence
   Files: `src/admin/AuditSummaryPanel.tsx`, `src/admin/AuditSummaryPanel.test.tsx`
   Read first: `tasks.md`, `task-manifest.json`
   Verification:
   - `npm test -- src/admin/AuditSummaryPanel.test.tsx`
   - `npm run lint -- src/admin/AuditSummaryPanel.tsx`
   Evidence: passing output + clean lint output
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T003`; do not hand-edit status.
+  Test seam: admin audit panel UI behavior
+  Public verification path: Run the audit summary panel test and observe CSV export through visible rows
+  Allowed mocks: download / blob boundary
   Ready when: T002 已完成

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-003.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.1`
+- CC-Plan skill version: `3.8.2`
 - Source roadmap item: `RM-020`
 - Source roadmap version: `roadmap.v3`
 

--- a/docs/examples/pdca-loop/README.md
+++ b/docs/examples/pdca-loop/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.1`, `cc-do@1.6.2`, `cc-check@1.10.1`, `cc-act@1.8.2`
+- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.2`, `cc-do@1.6.3`, `cc-check@1.10.1`, `cc-act@1.8.2`
 
 This folder shows one minimal but complete `cc-roadmap -> cc-plan -> cc-do -> cc-check -> cc-act` loop.
 

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/design.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-001.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.1`
+- CC-Plan skill version: `3.8.2`
 - Requirement ID: `REQ-001`
 - Design mode: `tiny-design`
 - Why this stays `tiny-design`: the patch is limited to an existing dialog and test file, with no API or data model changes

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
@@ -179,7 +179,60 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "red",
+      "verticalSlice": "Slice 1",
+      "testSeam": {
+        "entry": "share dialog UI behavior",
+        "behaviorAsserted": "The missing copy action is reproduced as a failing test",
+        "specStyleTestName": "The missing copy action is reproduced as a failing test",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the share dialog test and observe the copy action through the rendered dialog",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": "Fails before the behavior exists"
+      },
+      "allowedMocks": [
+        "clipboard boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T001",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T002",
@@ -231,7 +284,60 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "green",
+      "verticalSlice": "Slice 2",
+      "testSeam": {
+        "entry": "share dialog UI behavior",
+        "behaviorAsserted": "The dialog exposes a copy button and confirms the copied state",
+        "specStyleTestName": "The dialog exposes a copy button and confirms the copied state",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the share dialog test and observe the copy action through the rendered dialog",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "clipboard boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Implement only the code needed to pass the current red behavior",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T002",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     },
     {
       "id": "T003",
@@ -287,7 +393,60 @@
       },
       "status": "passed",
       "attempts": 1,
-      "maxRetries": 1
+      "maxRetries": 1,
+      "tddPhase": "evidence",
+      "verticalSlice": "Slice 3",
+      "testSeam": {
+        "entry": "share dialog UI behavior",
+        "behaviorAsserted": "Fresh verification evidence is ready for cc-check",
+        "specStyleTestName": "Fresh verification evidence is ready for cc-check",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Run the share dialog test and observe the copy action through the rendered dialog",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": ""
+      },
+      "allowedMocks": [
+        "clipboard boundary"
+      ],
+      "testQuality": {
+        "usesPublicInterface": true,
+        "describesBehavior": true,
+        "specStyleName": true,
+        "oneLogicalBehavior": true,
+        "verifiesThroughPublicPath": true,
+        "survivesInternalRefactor": true,
+        "mocksOnlySystemBoundaries": true,
+        "noBulkRed": true
+      },
+      "greenMinimality": {
+        "guard": "Keep the task scoped to its stated verification evidence",
+        "noSpeculativeBranches": true
+      },
+      "completion": {
+        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T003",
+        "requiredBeforeCompletion": [
+          "verification evidence captured",
+          "checkpoint written",
+          "spec review gate recorded",
+          "code review gate recorded"
+        ],
+        "forbiddenShortcuts": [
+          "manual checkbox edit",
+          "manual manifest status edit",
+          "leaving currentTaskId stale"
+        ]
+      },
+      "refactorCandidates": [
+        "duplication",
+        "long method",
+        "primitive obsession",
+        "naming",
+        "more than three nested branches"
+      ]
     }
   ],
   "metadata": {
@@ -297,5 +456,39 @@
   },
   "deferredQuestions": [
     "If users still miss the copied-state confirmation, open RM-002 for richer feedback."
-  ]
+  ],
+  "executionProtocol": {
+    "templateCompliance": {
+      "required": true,
+      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
+      "taskBlockMustInclude": [
+        "Goal",
+        "TDD phase",
+        "Files",
+        "Read first",
+        "Verification",
+        "Evidence",
+        "Test seam",
+        "Public verification path",
+        "Allowed mocks",
+        "Completion"
+      ],
+      "titleOnlyTasks": "forbidden"
+    },
+    "selection": {
+      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/select-ready-tasks.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json"
+    },
+    "completion": {
+      "manualStatusEdit": "forbidden",
+      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task <task-id>",
+      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
+      "updates": [
+        "planning/task-manifest.json.tasks[].status",
+        "planning/task-manifest.json.currentTaskId",
+        "planning/task-manifest.json.status",
+        "planning/tasks.md checkbox"
+      ]
+    }
+  }
 }

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
@@ -22,7 +22,7 @@
     ]
   },
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.1",
+    "reqPlanSkillVersion": "3.8.2",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-15T10:05:00.000Z",
     "approvedBy": "user",

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-001.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.1`
+- CC-Plan skill version: `3.8.2`
 - Source roadmap item: `RM-001`
 - Source roadmap version: `roadmap.v1`
 

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
@@ -39,34 +39,68 @@
 
 > 顶部 handoff 只保留执行者必须知道的现实，不重复讲背景故事。
 
+## Execution Protocol
+
+ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合同，而不是普通 TODO 列表。
+
+- Template source: `assets/TASKS_TEMPLATE.md`
+- Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
+- Task block rule: read the full task block before coding; title-only execution is invalid.
+- Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
+- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+
+```bash
+SCRIPT_ROOT=".claude/skills/cc-do/scripts"
+if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then
+  SCRIPT_ROOT=".codex/skills/cc-do/scripts"
+fi
+bash "$SCRIPT_ROOT/select-ready-tasks.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
+bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task <task-id>
+```
+
 ## Phase 1: Foundation
 
 - [x] T001 [TEST] Add a failing dialog test for the missing copy action (dependsOn:none) `src/features/share/ShareDialog.test.tsx`
   Goal: 证明当前 share dialog 还不能一键复制 invite link。
+  TDD phase: red
   Files: `src/features/share/ShareDialog.test.tsx`
   Read first: `design.md`, `src/features/share/ShareDialog.tsx`
   Verification: `npm test -- src/features/share/ShareDialog.test.tsx`
   Evidence: failing output that shows the missing button / action
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T001`; do not hand-edit status.
+  Test seam: share dialog UI behavior
+  Public verification path: Run the share dialog test and observe the copy action through the rendered dialog
+  Allowed mocks: clipboard boundary
   Ready when: 没有上游依赖，且现有 dialog test 已可运行
 
 - [x] T002 [IMPL] Add the copy button and copied-state confirmation (dependsOn:T001) `src/features/share/ShareDialog.tsx`
   Goal: 用最小实现让 T001 转绿，并保持当前 share contract 不变。
+  TDD phase: green
   Files: `src/features/share/ShareDialog.tsx`
   Read first: `design.md`, `src/features/share/ShareDialog.test.tsx`
   Verification: `npm test -- src/features/share/ShareDialog.test.tsx`
   Evidence: passing output + checkpoint + review notes
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T002`; do not hand-edit status.
+  Test seam: share dialog UI behavior
+  Public verification path: Run the share dialog test and observe the copy action through the rendered dialog
+  Allowed mocks: clipboard boundary
   Ready when: T001 已经见红，且当前 touched files 没有外部依赖阻塞
 
 ## Phase 2: Verify
 
 - [x] T003 Run targeted checks and collect fresh evidence (dependsOn:T002) `share dialog quality gates`
   Goal: 为 `cc-check` 准备本次实现的真实验证证据。
+  TDD phase: evidence
   Files: `src/features/share/ShareDialog.tsx`, `src/features/share/ShareDialog.test.tsx`
   Read first: `tasks.md`, `task-manifest.json`
   Verification:
   - `npm test -- src/features/share/ShareDialog.test.tsx`
   - `npm run lint -- src/features/share/ShareDialog.tsx`
   Evidence: passing test output + clean lint output
+  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T003`; do not hand-edit status.
+  Test seam: share dialog UI behavior
+  Public verification path: Run the share dialog test and observe the copy action through the rendered dialog
+  Allowed mocks: clipboard boundary
   Ready when: T002 已完成，且 review gate 已可补齐
 
 > `[P]` 只表示“依赖满足后有资格并行”，不表示可以无脑同时开发。

--- a/docs/examples/scripts/check-example-bindings.sh
+++ b/docs/examples/scripts/check-example-bindings.sh
@@ -93,8 +93,18 @@ while IFS= read -r encoded; do
 
   jq -er --arg roadmap "$ROADMAP_VERSION" --arg reqplan "$REQ_PLAN_VERSION" '
     (.sourceRoadmap.roadmapSkillVersion // $roadmap) == $roadmap and
-    (.planningMeta.reqPlanSkillVersion // $reqplan) == $reqplan
+    (.planningMeta.reqPlanSkillVersion // $reqplan) == $reqplan and
+    .executionProtocol.templateCompliance.required == true and
+    .executionProtocol.completion.manualStatusEdit == "forbidden" and
+    (.executionProtocol.completion.commandTemplate | contains("mark-task-complete.sh")) and
+    all(.tasks[]; (.completion.command | contains("mark-task-complete.sh")) and (.tddPhase | type == "string") and (.testSeam.publicVerificationPath | type == "string"))
   ' "$planning_dir/task-manifest.json" >/dev/null
+
+  assert_contains "$planning_dir/tasks.md" "## Execution Protocol"
+  assert_contains "$planning_dir/tasks.md" "mark-task-complete.sh"
+  assert_contains "$planning_dir/tasks.md" "TDD phase:"
+  assert_contains "$planning_dir/tasks.md" "Completion:"
+  assert_contains "$planning_dir/tasks.md" "Public verification path:"
 
   assert_contains "$readme" "## Example Meta"
   assert_contains "$readme" "\`cc-roadmap@$ROADMAP_VERSION\`"

--- a/test/validate-publish.test.js
+++ b/test/validate-publish.test.js
@@ -192,9 +192,16 @@ describe('validate-publish', () => {
     expect(manifest).toContain('"aiLeverageDecisionLens"');
     expect(manifest).toContain('"humanTeamEffortForFullScope"');
     expect(manifest).toContain('"completeLakeBoundary"');
-    expect(parsedManifest.planningMeta.reqPlanSkillVersion).toBe('3.8.1');
+    expect(parsedManifest.planningMeta.reqPlanSkillVersion).toBe('3.8.2');
     expect(parsedManifest.sourceRoadmap.roadmapSkillVersion).toBe('5.2.0');
     expect(planningContract).toContain('AI Leverage Decision Lens 必须在任务生成前闭合');
+    expect(skill).toContain('## ClaudeCode / Codex Execution Compliance');
+    expect(tasks).toContain('## Execution Protocol');
+    expect(tasks).toContain('mark-task-complete.sh');
+    expect(parsedManifest.executionProtocol.templateCompliance.required).toBe(true);
+    expect(parsedManifest.executionProtocol.completion.manualStatusEdit).toBe('forbidden');
+    expect(parsedManifest.tasks[0].completion.command).toContain('mark-task-complete.sh');
+    expect(planningContract).toContain('## Execution Protocol Fields');
   });
 
   test('cc-roadmap carries the AI leverage route lens contract', () => {


### PR DESCRIPTION
## Summary
- make cc-simplify automatically trigger read-only reviewer subagents when the host supports them
- require cc-plan outputs to include task-template compliance and script-driven completion protocol
- require cc-do task completion to use mark-task-complete.sh instead of manual status edits

## Test Plan
- [x] npm run adapt:codex
- [x] npm run adapt:check
- [x] npm run verify:examples
- [x] npm run verify:publish
- [x] npm test -- --runInBand
- [x] git diff --check