### PR TITLE
chore(release): publish 4.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.8] - 2026-05-11
+
 ### Changed
 
 - Updated `cc-review` with a risk-lane review swarm profile so broad implementation and PR-landing reviews separate intent/regression, security/privacy, performance/reliability, and contracts/coverage findings before main-thread triage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cc-devflow",
-    "version": "4.5.7",
+    "version": "4.5.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cc-devflow",
-            "version": "4.5.7",
+            "version": "4.5.8",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cc-devflow",
-    "version": "4.5.7",
+    "version": "4.5.8",
     "description": "Multi-platform CLI and skill pack for agent coding",
     "main": "bin/cc-devflow.js",
     "bin": {


### PR DESCRIPTION
## Summary
- Bump cc-devflow to 4.5.8
- Move the current changelog entries from Unreleased into the 4.5.8 release section
- Publish cc-devflow@4.5.8 to npm

## Test Plan
- [x] npm run adapt:check
- [x] npm run verify:examples
- [x] npm run verify:publish
- [x] npm test -- --runInBand
- [x] npm publish --dry-run --access public
- [x] npm view cc-devflow version
- [x] npm view cc-devflow@4.5.8 bin --json
- [x] npx --yes cc-devflow@4.5.8 --help