### PR TITLE
feat(skills): slim artifact state contracts

### DIFF
--- a/.claude/skills/cc-act/CHANGELOG.md
+++ b/.claude/skills/cc-act/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CC-Act Skill Changelog
 
+## v1.8.4 - 2026-05-11
+
+- prefer `change-meta.json` for roadmap sync and spec file summaries so `task-manifest.json` stays focused on execution state
+- keep backward-compatible manifest fallback for older change folders while preserving one owner for roadmap/spec status
+
 ## v1.8.3 - 2026-05-11
 
 - add `ensure-ship-branch.sh` so detached HEAD closeouts can create a named branch and continue toward `create-pr`

--- a/.claude/skills/cc-act/SKILL.md
+++ b/.claude/skills/cc-act/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-act
-version: 1.8.3
+version: 1.8.4
 description: 'Use when verified work must be shipped or handed off with a clear landing path: run simplify and required tests, create or update a PR, prepare a local handoff, close out merged work, sync docs, write release notes, and fold follow-ups back into backlog or roadmap.'
 triggers:
   - 准备提 PR

--- a/.claude/skills/cc-act/scripts/cc-act-common.sh
+++ b/.claude/skills/cc-act/scripts/cc-act-common.sh
@@ -34,6 +34,10 @@ req_act_manifest_path() {
   printf '%s/task-manifest.json\n' "$(req_act_planning_dir "$1")"
 }
 
+req_act_change_meta_path() {
+  printf '%s/change-meta.json\n' "$(req_act_change_dir "$1")"
+}
+
 req_act_tasks_path() {
   printf '%s/tasks.md\n' "$(req_act_planning_dir "$1")"
 }
@@ -243,11 +247,22 @@ req_act_collect_touched_files() {
 req_act_collect_spec_files() {
   local manifest="$1"
   local out_file="$2"
+  local change_dir=""
+  local change_meta=""
 
   : > "$out_file"
 
   if [[ -f "$manifest" ]]; then
-    jq -r '(.spec.specFiles // [])[]?' "$manifest" 2>/dev/null | sed '/^$/d' > "$out_file" || true
+    change_dir="$(req_act_change_dir "$(dirname "$manifest")")"
+    change_meta="$(req_act_change_meta_path "$change_dir")"
+  fi
+
+  if [[ -n "$change_meta" && -f "$change_meta" ]]; then
+    jq -r '(.spec.specFiles // [])[]?' "$change_meta" 2>/dev/null | sed '/^$/d' > "$out_file" || true
+  fi
+
+  if [[ -f "$manifest" ]]; then
+    jq -r '(.spec.specFiles // [])[]?' "$manifest" 2>/dev/null | sed '/^$/d' >> "$out_file" || true
   fi
 
   req_act_dedup_file "$out_file"
@@ -262,8 +277,21 @@ req_act_roadmap_sync_summary() {
   local no_op_reason=""
   local updated_files=""
   local existing_files=""
+  local change_dir=""
+  local change_meta=""
 
   if [[ -f "$manifest" ]]; then
+    change_dir="$(req_act_change_dir "$(dirname "$manifest")")"
+    change_meta="$(req_act_change_meta_path "$change_dir")"
+  fi
+
+  if [[ -n "$change_meta" && -f "$change_meta" ]]; then
+    item_id="$(jq -r '.sourceRoadmap.itemId // empty' "$change_meta" 2>/dev/null || true)"
+    sync_status="$(jq -r '.roadmapSync.status // .sourceRoadmap.syncStatus // "not recorded"' "$change_meta" 2>/dev/null || true)"
+    sync_command="$(jq -r '.roadmapSync.command // .sourceRoadmap.syncCommand // empty' "$change_meta" 2>/dev/null || true)"
+    no_op_reason="$(jq -r '.roadmapSync.noOpReason // .sourceRoadmap.noOpReason // empty' "$change_meta" 2>/dev/null || true)"
+    updated_files="$(jq -r '(.roadmapSync.updatedFiles // .sourceRoadmap.updatedFiles // []) | join(", ")' "$change_meta" 2>/dev/null || true)"
+  elif [[ -f "$manifest" ]]; then
     item_id="$(jq -r '.sourceRoadmap.itemId // empty' "$manifest" 2>/dev/null || true)"
     sync_status="$(jq -r '.sourceRoadmap.syncStatus // .roadmapSync.status // "not recorded"' "$manifest" 2>/dev/null || true)"
     sync_command="$(jq -r '.sourceRoadmap.syncCommand // .roadmapSync.command // empty' "$manifest" 2>/dev/null || true)"

--- a/.claude/skills/cc-do/CHANGELOG.md
+++ b/.claude/skills/cc-do/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CC-Do Skill Changelog
 
+## v1.6.4 - 2026-05-11
+
+- stop writing derived top-level `task-manifest.json.status`; task completion is owned by `tasks[].status` and aggregate state is derived
+- read capability/spec handoff from `change-meta.json` first when building task context, keeping spec sync state out of task manifests
+
 ## v1.6.3 - 2026-05-10
 
 - require task completion to go through `scripts/mark-task-complete.sh` instead of manual checkbox or manifest edits

--- a/.claude/skills/cc-do/SKILL.md
+++ b/.claude/skills/cc-do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-do
-version: 1.6.3
+version: 1.6.4
 description: Use when implementing planned tasks, resuming interrupted work, applying a frozen investigation handoff, or landing review feedback after cc-plan or cc-investigate.
 triggers:
   - 开始做 T003

--- a/.claude/skills/cc-do/scripts/build-task-context.sh
+++ b/.claude/skills/cc-do/scripts/build-task-context.sh
@@ -85,11 +85,15 @@ completed_tasks="$(jq -r '
 ready_tasks="$(echo "$ready_json" | jq -r '.readyTasks[]?.id')"
 running_tasks="$(echo "$ready_json" | jq -r '.runningTasks[]?.id')"
 active_phase="$(echo "$ready_json" | jq -r '.activePhase // "unknown"')"
-primary_capability="$(jq -r '.spec.primaryCapability // empty' "$manifest" 2>/dev/null || true)"
-secondary_capabilities="$(jq -r '(.spec.secondaryCapabilities // [])[]?' "$manifest" 2>/dev/null || true)"
-spec_files="$(jq -r '(.spec.specFiles // [])[]?' "$manifest" 2>/dev/null || true)"
-expected_delta="$(jq -r '(.spec.expectedDelta // [])[]?' "$manifest" 2>/dev/null || true)"
-sync_status="$(jq -r '.spec.syncStatus // "unknown"' "$manifest" 2>/dev/null || true)"
+spec_source="$manifest"
+if [[ -f "$change_meta" ]]; then
+  spec_source="$change_meta"
+fi
+primary_capability="$(jq -r '.spec.primaryCapability // empty' "$spec_source" 2>/dev/null || true)"
+secondary_capabilities="$(jq -r '(.spec.secondaryCapabilities // [])[]?' "$spec_source" 2>/dev/null || true)"
+spec_files="$(jq -r '(.spec.specFiles // [])[]?' "$spec_source" 2>/dev/null || true)"
+expected_delta="$(jq -r '(.spec.expectedDelta // [])[]?' "$spec_source" 2>/dev/null || true)"
+sync_status="$(jq -r '.spec.syncStatus // "unknown"' "$spec_source" 2>/dev/null || true)"
 
 {
   echo "# Task Context"

--- a/.claude/skills/cc-do/scripts/mark-task-complete.sh
+++ b/.claude/skills/cc-do/scripts/mark-task-complete.sh
@@ -95,12 +95,6 @@ if [[ -n "$MANIFEST" ]]; then
   tmp_manifest="$(mktemp)"
   jq --arg next "$next_task" '
     .currentTaskId = (if $next == "" then null else $next end)
-    | .status = (
-        if ([.tasks[] | select((.status // "pending") != "passed" and (.status // "pending") != "completed" and (.status // "pending") != "done" and (.status // "pending") != "verified")] | length) == 0
-        then "implemented"
-        else "in_progress"
-        end
-      )
   ' "$MANIFEST" > "$tmp_manifest"
   mv "$tmp_manifest" "$MANIFEST"
 fi

--- a/.claude/skills/cc-investigate/CHANGELOG.md
+++ b/.claude/skills/cc-investigate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CC-Investigate Skill Changelog
 
+## v1.3.1 - 2026-05-11
+
+- slim investigation task manifests so roadmap/spec status stays owned by `change-meta.json` and `devflow/roadmap.json`
+- remove duplicate design/review/status mirrors from the investigation manifest template while keeping root-cause evidence in `planning/analysis.md`
+
 ## v1.3.0 - 2026-05-09
 
 - FIX change key assignment now uses `cc-devflow next-change-key` instead of prose instructions

--- a/.claude/skills/cc-investigate/SKILL.md
+++ b/.claude/skills/cc-investigate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-investigate
-version: 1.3.0
+version: 1.3.1
 description: "Use when a bug, regression, broken task, or unexpected behavior needs root-cause investigation, reproducible evidence, and a frozen repair handoff before cc-do resumes coding."
 triggers:
   - "帮我查这个 bug"

--- a/.claude/skills/cc-investigate/assets/ANALYSIS_TEMPLATE.md
+++ b/.claude/skills/cc-investigate/assets/ANALYSIS_TEMPLATE.md
@@ -13,6 +13,13 @@
 - Primary capability:
 - Related capability specs:
 
+## Progressive Disclosure Index
+
+- Default read: Symptom, Feedback Loop Contract, Confirmed Root Cause, Repair Boundary.
+- Open for root-cause doubt: Evidence Chain, Boundary Probe Matrix, Backward Trace Chain, Hypothesis Ledger.
+- Open for workflow failures: Workflow Forensics, Debug Session, Cleanup Checklist.
+- Open for handoff/audit: Prevention Handoff, Roadmap Sync Gate, Review Notes.
+
 ## Symptom
 
 - What the user saw:

--- a/.claude/skills/cc-investigate/assets/TASKS_TEMPLATE.md
+++ b/.claude/skills/cc-investigate/assets/TASKS_TEMPLATE.md
@@ -10,6 +10,13 @@
 - Roadmap sync status:
 - Change meta: `change-meta.json`
 
+## Progressive Disclosure Index
+
+- Default read: Investigation Meta, Execution Handoff, current task block.
+- Open for root-cause doubt: `planning/analysis.md` Feedback Loop, Evidence Chain, Boundary Probe Matrix.
+- Open for scheduling: `planning/task-manifest.json`, dependencies, touched files.
+- Open for audit/recovery: checkpoint files, report-card findings, Workflow Forensics.
+
 ## Execution Handoff
 
 - Canonical analysis: `planning/analysis.md`

--- a/.claude/skills/cc-investigate/assets/TASK_MANIFEST_TEMPLATE.json
+++ b/.claude/skills/cc-investigate/assets/TASK_MANIFEST_TEMPLATE.json
@@ -5,33 +5,10 @@
   "outputPolicy": {
     "documentLanguage": ""
   },
-  "sourceRoadmap": {
-    "itemId": "RM-001",
-    "roadmapVersion": "1.0",
-    "roadmapSkillVersion": "2.1.0",
-    "syncStatus": "pending",
-    "syncCommand": ".claude/skills/cc-roadmap/scripts/sync-roadmap-progress.sh --rm RM-001 --status \"Repair planned\" --req FIX-XXX --progress 0%",
-    "updatedFiles": [
-      "devflow/roadmap.json",
-      "devflow/ROADMAP.md",
-      "devflow/BACKLOG.md"
-    ],
-    "noOpReason": "",
-    "sourceStage": "Stage 1",
-    "successSignal": "The broken behavior is reproducible and then fixed without widening scope",
-    "killSignal": "Repair requires reopening product scope or redesigning unrelated modules",
-    "dependencies": [
-      "The existing product contract still applies"
-    ],
-    "nonGoals": [
-      "No unrelated feature additions"
-    ]
-  },
   "planningMeta": {
-    "ccInvestigateSkillVersion": "1.2.2",
+    "ccInvestigateSkillVersion": "1.3.1",
     "analysisVersion": "analysis.v1",
     "approvedAt": "2026-04-17T12:00:00.000Z",
-    "approvedBy": "user",
     "basedOnRootCause": "Root cause sentence"
   },
   "investigationMeta": {
@@ -171,35 +148,7 @@
       "splitOrRerouteDecision": "single focused repair"
     }
   },
-  "status": "planned",
-  "designMode": "cc-investigate",
-  "approvedOption": "confirmed-root-cause",
-  "designStatus": "approved",
-  "reviewStatus": "approved",
-  "spec": {
-    "primaryCapability": "cap-example",
-    "secondaryCapabilities": [],
-    "expectedDelta": [
-      "Repair capability truth without widening scope"
-    ],
-    "affectedInvariants": [],
-    "gapsClosed": [],
-    "newGaps": [],
-    "specFiles": [
-      "devflow/specs/capabilities/cap-example.md"
-    ],
-    "syncStatus": "planned",
-    "diagnosis": "implementation drift"
-  },
-  "tasteDecisions": [],
-  "userChallenges": [],
   "currentTaskId": "T001",
-  "activePhase": 1,
-  "frozenDecisions": [
-    "Fix only the confirmed root cause",
-    "Use planning/analysis.md as the canonical root-cause contract",
-    "Do not widen scope without rerouting to cc-plan"
-  ],
   "tasks": [
     {
       "id": "T001",
@@ -244,11 +193,14 @@
       "reviews": {
         "spec": "pending",
         "code": "pending"
-      }
+      },
+      "type": "TEST",
+      "run": [
+        "npm test -- src/feature/feature.test.ts"
+      ],
+      "checks": [],
+      "attempts": 0,
+      "maxRetries": 1
     }
-  ],
-  "openQuestions": [],
-  "deferredQuestions": [
-    "If the fix expands beyond the frozen repair boundary, reroute to cc-plan"
   ]
 }

--- a/.claude/skills/cc-plan/CHANGELOG.md
+++ b/.claude/skills/cc-plan/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CC-Plan Skill Changelog
 
+## v3.8.3 - 2026-05-11
+
+- slim `task-manifest.json` back to execution graph truth instead of duplicating `planning/design.md` and `planning/tasks.md`
+- retire manifest-only narrative/protocol/status mirrors: top-level `status`, `activePhase`, `sourceRoadmap`, `spec`, `executionProtocol`, `planningMeta.requirementBrief`, `planningMeta.ambiguityGate`, `planningMeta.reviewLoop`, `sourceEvidence[]`, `languageAndDecisions`, `executionDiscipline`, and task-level `completion`
+- keep roadmap/spec state in `change-meta.json` and `devflow/roadmap.json`, task completion commands in `planning/tasks.md`, and execution graph state in `task-manifest.json`
+- add progressive disclosure indexes to design and task templates so lower-frequency context is opened only when needed
+
 ## v3.8.2 - 2026-05-10
 
 - require `cc-plan` to generate executable tasks from the bundled task template instead of loose Markdown checklists

--- a/.claude/skills/cc-plan/SKILL.md
+++ b/.claude/skills/cc-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-plan
-version: 3.8.2
+version: 3.8.3
 description: Use when a requirement, roadmap item, or bug needs scope clarification, design decisions, and executable task breakdown before coding starts.
 triggers:
   - 帮我规划这个需求
@@ -46,7 +46,7 @@ entry_gate:
   - "For non-trivial designs, compare named option roles: minimal viable, ideal architecture, and optional hybrid. Do not default to smallest unless it best serves the goal."
   - Plan executable work as Red/Green/Refactor by default; identify the first failing test before any production implementation task, or write an explicit TDD exception with replacement evidence.
   - Generate `planning/tasks.md` from `assets/TASKS_TEMPLATE.md` semantics, including every required task field, the execution protocol, and the exact task completion command; do not free-form a loose checklist.
-  - Generate `planning/task-manifest.json.executionProtocol` so ClaudeCode / Codex execution can select ready tasks and mark completion through scripts instead of hand-editing status.
+  - "Keep `planning/task-manifest.json` lean: it is the machine execution graph, not a mirror of the design narrative or task protocol prose."
   - For behavior changes, freeze the spec-style test name, one logical behavior, public verification path, and interface-testability decision before task split.
   - "Before approach approval, run the AI Leverage Decision Lens: real user/operator, status quo workaround, human-vs-agent effort, complete-lake boundary, ocean boundary, scope recommendation, and boil-lake/sharp-wedge/needs-evidence/pivot verdict."
   - Before approach approval, decide whether external best-practice validation could materially change the plan; if yes, ask the user through the Decision Question Protocol before any web or external lookup.
@@ -58,7 +58,7 @@ exit_criteria:
   - planning/design.md captures the approved solution, PRD-grade requirement brief, boundaries, review conclusions, and execution edge cases.
   - planning/tasks.md, planning/task-manifest.json, and change-meta.json are explicit enough that cc-do can continue without chat memory.
   - planning/tasks.md contains the task-template compliance section and script-based completion protocol, and every task block includes its completion command.
-  - task-manifest.json records `executionProtocol.templateCompliance.required = true` and a `completion.commandTemplate` that calls `mark-task-complete.sh`.
+  - task-manifest.json omits retired narrative/protocol mirrors such as `executionProtocol`, `planningMeta.requirementBrief`, `planningMeta.ambiguityGate`, `planningMeta.reviewLoop`, and task-level `completion`; those details belong in `planning/design.md` or `planning/tasks.md`.
   - The task breakdown preserves test-first execution; failing-test tasks precede implementation tasks, refactor checkpoints are visible, and any TDD exception is justified.
   - "Testability decisions make the public seam natural: small interface, deep implementation, injected boundary dependencies, returned results where practical, and boundary mocks only where the system genuinely leaves the repo."
   - AI Leverage Decision Lens is recorded in planning/design.md and task-manifest.json.planningMeta.aiLeverageDecisionLens before executable tasks are generated.
@@ -191,7 +191,8 @@ bash .claude/skills/cc-plan/scripts/next-change-key.sh --prefix REQ --descriptio
 3. `planning/task-manifest.json`
    - 从 `planning/tasks.md` 编译出的机器真相源
    - 只服务执行与调度，不再承担人类阅读的叙事职责
-   - 必须包含 `executionProtocol`：模板字段完整性、ready-task 选择命令、任务完成命令、禁止手工修改状态
+   - 只保留版本链、当前任务、任务依赖、触点、验证命令、证据、review 状态和必要 planning gate 结果
+   - 不再镜像 `design.md` 的 PRD brief / ambiguity / review loop，也不再镜像 `tasks.md` 的执行协议或 completion shell 命令
 4. `change-meta.json`
    - 绑定 roadmap item、primary capability、secondary capabilities、expected spec delta、spec sync status
    - 作为 `cc-do`、`cc-check`、`cc-act` 的 capability 机器真相源
@@ -206,6 +207,17 @@ bash .claude/skills/cc-plan/scripts/next-change-key.sh --prefix REQ --descriptio
 
 这些信息如果仍然需要，必须并入 `planning/design.md` 或 `planning/tasks.md`，而不是再拆新文件。
 
+## Progressive Disclosure
+
+精简不等于把仍有价值的信息全部删掉。`cc-plan` 的输出必须按“默认必读 -> 条件展开 -> 深层审查”分层，让执行者按需加载上下文。
+
+- 第一屏必须能回答：这次做什么、不做什么、为什么现在做、当前批准状态、下一步读哪个 task。
+- `planning/design.md` 顶部必须有 progressive disclosure index：默认读 Requirement Snapshot / Approved Direction / Validation / Roadmap Sync；只有遇到范围、信任、外部资料、UI/DX、风险或复盘问题时才展开对应深层区块。
+- `planning/tasks.md` 顶部必须有 progressive disclosure index：默认读 Plan Meta、Execution Handoff、Execution Protocol、当前 task block；只有并行冲突、切片争议或质量审查时才展开 surface map、tracer map 和 Task Quality Bar。
+- `planning/task-manifest.json` 只做机器索引和执行图，不复制深层说明。它可以告诉执行者当前任务、依赖、触点、命令和证据，但不能把 PRD、review gate、completion protocol 重新展开一遍。
+- 深层信息必须有明确打开条件；如果一段内容没有打开条件，也没有下游消费方，就删掉。
+- 所有 SKILL 都遵守 `docs/guides/artifact-contract.md`：一个状态只能有一个 owner；其它 artifact 只能引用、投影或派生。
+
 ## ClaudeCode / Codex Execution Compliance
 
 `cc-plan` 不能只产出“看起来像任务”的列表。它必须把执行者遵循任务模板和状态脚本的能力写进 durable artifacts，尤其是 ClaudeCode 这类容易把 Markdown checklist 当普通 TODO 的宿主。
@@ -218,14 +230,14 @@ bash .claude/skills/cc-plan/scripts/next-change-key.sh --prefix REQ --descriptio
 4. 任务完成后必须调用 `mark-task-complete.sh` 同步 `planning/task-manifest.json` 和 `planning/tasks.md`；禁止手工把 checkbox 改成 `[x]`，禁止只改 manifest，禁止完成后不标记。
 5. 如果完成脚本失败，不能手改绕过；先修复缺失 gate、checkpoint 或 review evidence，再重跑脚本。
 
-生成 `planning/task-manifest.json` 时必须写入：
+生成 `planning/task-manifest.json` 时必须保持瘦身边界：
 
-- `executionProtocol.templateCompliance.required = true`
-- `executionProtocol.templateCompliance.sourceTemplate = "assets/TASKS_TEMPLATE.md"`
-- `executionProtocol.selection.commandTemplate`
-- `executionProtocol.completion.commandTemplate`
-- `executionProtocol.completion.manualStatusEdit = "forbidden"`
-- 每个 `tasks[]` 的 `completion` 字段，至少包含 command、requiredBeforeCompletion、forbiddenShortcuts。
+- 保留 `currentTaskId`、`tasks[].dependsOn`、`tasks[].parallel`、`tasks[].touches`、`tasks[].run`、`tasks[].checks`、`tasks[].verification`、`tasks[].evidence`、`tasks[].reviews`。
+- 保留 `planningMeta.aiLeverageDecisionLens`、`planningMeta.externalBestPractice`、`planningMeta.decisionQuestions`，因为它们会影响任务能否进入执行。
+- 禁止写入顶层 `status`、`activePhase`、`sourceRoadmap`、`spec`、`executionProtocol`、`planningMeta.requirementBrief`、`planningMeta.ambiguityGate`、`planningMeta.reviewLoop`、`sourceEvidence[]`、`languageAndDecisions`、`executionDiscipline` 和每个 task 的 `completion` 字段。
+- PRD brief、ambiguity gate、bounded review loop、source trust boundary、语言/冲突分类保留在 `planning/design.md`。
+- ready-task 选择和 completion shell 命令保留在 `planning/tasks.md` 的 `Execution Protocol` 和每个 task block。
+- Roadmap progress 和 capability/spec sync 状态由 `change-meta.json` / `devflow/roadmap.json` 持有，`task-manifest.json` 不复制。
 
 脚本路径必须支持 ClaudeCode 和 Codex mirror：
 
@@ -545,7 +557,7 @@ STOP: wait for the user answer before continuing.
 - `planning/tasks.md` 只保留能直接执行的任务和 handoff，不再承载重复背景介绍；行为变更默认拆成 tracer bullet 形式的 `[TEST] -> [IMPL] -> [REFACTOR]`，且 Red task 明确 spec-style test name、单一行为、公共 seam、行为断言、mock 边界和反馈循环
 - `planning/tasks.md` 必须把 `assets/TASKS_TEMPLATE.md` 的任务字段实例化到每个 task；不能只生成标题清单，也不能让 ClaudeCode / Codex 靠猜测补字段
 - `planning/tasks.md` 必须写出任务完成脚本，要求执行者完成每个 task 后调用 `mark-task-complete.sh`，禁止手动勾选或漏标
-- `planning/task-manifest.json` 是 `cc-do` 的真相源，要写清 `planningMeta.requirementBrief`、`planningMeta.ambiguityGate`、`planningMeta.reviewLoop`、`executionProtocol`、`sourceEvidence[]`、`dependsOn`、`tddPhase`、`verticalSlice`、test seam、public verification path、allowed mocks、feedback loop、minimality guard、refactor candidates、completion command、并行资格、触点、验证命令，以及继承了哪版 roadmap / design / spec
+- `planning/task-manifest.json` 是 `cc-do` 的机器真相源，只写执行图和必要 gate：版本链、`currentTaskId`、`dependsOn`、`parallel`、触点、run/check/verification/evidence、review 状态、`tddPhase`、`verticalSlice`、test seam、feedback loop，以及会阻塞执行的 AI leverage / external-best-practice / decision-question 结果；roadmap/spec 状态归 `change-meta.json` 和 `devflow/roadmap.json`，PRD brief、ambiguity、review loop、source trust、completion 命令留在 `planning/design.md` 或 `planning/tasks.md`
 - `change-meta.json` 是 capability 真相源，要写清这次 change 准备如何改变长期 spec
 - roadmap sync 不是聊天提醒：如果 source RM 存在，必须更新 `devflow/roadmap.json` 并重新生成 `devflow/ROADMAP.md` / `devflow/BACKLOG.md`；如果不存在，必须记录 no-op reason
 - 看完第一屏，执行者就知道这次属于 `tiny-design` 还是 `full-design`，以及为什么

--- a/.claude/skills/cc-plan/assets/DESIGN_TEMPLATE.md
+++ b/.claude/skills/cc-plan/assets/DESIGN_TEMPLATE.md
@@ -19,6 +19,13 @@
 - Date:
 - Owner:
 
+## Progressive Disclosure Index
+
+- Default read: Requirement Snapshot, Approved Direction, Validation Strategy, Roadmap Sync Gate.
+- Open for scope/design questions: Source Handoff, Options Considered, Design, Implementation Surface Map.
+- Open for trust/conflict questions: Source Trust Boundary, External Document Conflicts, Domain Language & Durable Decisions.
+- Open for audit/recovery: Review Gate, Bounded Review Loop, Decision Questions, Risks.
+
 ## Source Handoff
 
 - Source stage:

--- a/.claude/skills/cc-plan/assets/TASKS_TEMPLATE.md
+++ b/.claude/skills/cc-plan/assets/TASKS_TEMPLATE.md
@@ -11,6 +11,13 @@
 - Roadmap sync status:
 - Change meta: `change-meta.json`
 
+## Progressive Disclosure Index
+
+- Default read: Plan Meta, Execution Handoff, Execution Protocol, current task block.
+- Open for scheduling: `planning/task-manifest.json`, ready-task selector output, dependencies, touched files.
+- Open for parallel or ownership questions: Implementation Surface Map, Tracer Bullet Map.
+- Open for audit/recovery: Task Quality Bar, checkpoint files, review/report-card.json.
+
 ## Execution Handoff
 
 - Canonical design: `planning/design.md`

--- a/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
+++ b/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
@@ -1,57 +1,18 @@
 {
   "changeId": "REQ-XXX",
+  "goal": "Deliver planned requirement changes safely.",
+  "createdAt": "2026-05-11T00:00:00.000Z",
+  "updatedAt": "2026-05-11T00:00:00.000Z",
   "requirementId": "REQ-XXX",
   "requirementVersion": "REQ-XXX.v1",
   "outputPolicy": {
     "documentLanguage": ""
   },
-  "sourceRoadmap": {
-    "itemId": "RM-001",
-    "roadmapVersion": "1.0",
-    "roadmapSkillVersion": "5.2.0",
-    "syncStatus": "pending",
-    "syncCommand": ".claude/skills/cc-roadmap/scripts/sync-roadmap-progress.sh --rm RM-001 --status Planned --req REQ-XXX --progress 0%",
-    "updatedFiles": [
-      "devflow/roadmap.json",
-      "devflow/ROADMAP.md",
-      "devflow/BACKLOG.md"
-    ],
-    "noOpReason": "",
-    "sourceStage": "Stage 1",
-    "successSignal": "User can complete the new flow without manual workaround",
-    "killSignal": "Implementation requires reworking unrelated modules",
-    "dependencies": [
-      "Existing auth/session contract stays unchanged"
-    ],
-    "nonGoals": [
-      "No redesign of unrelated settings screens"
-    ]
-  },
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.2",
+    "reqPlanSkillVersion": "3.8.3",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-15T12:00:00.000Z",
-    "approvedBy": "user",
     "basedOnOption": "Option A",
-    "requirementBrief": {
-      "problemStatement": "The user-perspective problem this requirement solves.",
-      "solutionSummary": "The user-perspective solution after the requirement lands.",
-      "actors": [],
-      "userStories": [
-        {
-          "id": "US-001",
-          "actor": "",
-          "want": "",
-          "benefit": "",
-          "acceptance": []
-        }
-      ],
-      "edgeOrRecoveryStories": [],
-      "implementationDecisions": [],
-      "testingDecisions": [],
-      "outOfScope": [],
-      "furtherNotes": []
-    },
     "aiLeverageDecisionLens": {
       "realUserOrOperator": "",
       "statusQuoWorkaround": "",
@@ -72,21 +33,6 @@
       "verdict": "sharp-wedge",
       "missingEvidenceOrPivotReason": "",
       "impactOnApprovedDirection": ""
-    },
-    "ambiguityGate": {
-      "whatScore": 0,
-      "whyScore": 0,
-      "blockingThreshold": 3,
-      "status": "pass",
-      "assumptionsPreview": [],
-      "blockedQuestions": []
-    },
-    "reviewLoop": {
-      "attempt": 1,
-      "maxAttempts": 3,
-      "repeatedConcernFingerprints": [],
-      "stallReason": "",
-      "rerouteIfStalled": "ask-user"
     },
     "externalBestPractice": {
       "needed": false,
@@ -131,187 +77,24 @@
       }
     ]
   },
-  "executionProtocol": {
-    "templateCompliance": {
-      "required": true,
-      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
-      "taskBlockMustInclude": [
-        "Goal",
-        "TDD phase",
-        "Files",
-        "Read first",
-        "Verification",
-        "Evidence",
-        "Test seam",
-        "Public verification path",
-        "Allowed mocks",
-        "Completion"
-      ],
-      "titleOnlyTasks": "forbidden"
-    },
-    "selection": {
-      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT/select-ready-tasks.sh\" --manifest devflow/changes/<change-key>/planning/task-manifest.json"
-    },
-    "completion": {
-      "manualStatusEdit": "forbidden",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT/mark-task-complete.sh\" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task <task-id>",
-      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
-      "updates": [
-        "planning/task-manifest.json.tasks[].status",
-        "planning/task-manifest.json.currentTaskId",
-        "planning/task-manifest.json.status",
-        "planning/tasks.md checkbox"
-      ]
-    }
-  },
-  "sourceEvidence": [
-    {
-      "source": "planning/design.md",
-      "trust": "internal-contract",
-      "useAs": "contract",
-      "instructionRisk": "low",
-      "decision": "authoritative for this requirement"
-    }
-  ],
-  "languageAndDecisions": {
-    "languageSources": [],
-    "canonicalTerms": [],
-    "languageConflicts": [],
-    "decisionDocs": [],
-    "adrOrSpecConflicts": [],
-    "externalDocConflicts": {
-      "autoResolved": [],
-      "competing": [],
-      "unresolved": []
-    }
-  },
-  "executionDiscipline": {
-    "default": "red-green-refactor",
-    "taskShape": "vertical-tracer-bullets",
-    "testFirstRequired": true,
-    "testFrameworkSource": "",
-    "testQualityPolicy": {
-      "publicInterfaceRequired": true,
-      "behaviorAssertionRequired": true,
-      "specStyleTestNameRequired": true,
-      "oneLogicalBehaviorPerRed": true,
-      "publicVerificationPathRequired": true,
-      "mockBoundary": "system-boundaries-only",
-      "implementationDetailTests": "blocked",
-      "bulkRedTests": "blocked",
-      "boundaryAdapterShape": "specific-operations-preferred",
-      "feedbackLoopPreference": [
-        "automated-test",
-        "http-curl",
-        "cli-fixture",
-        "browser-script",
-        "trace-replay",
-        "throwaway-harness",
-        "property-fuzz",
-        "differential-loop",
-        "hitl-script"
-      ]
-    },
-    "regressionTestsRequired": [],
-    "tddExceptions": []
-  },
-  "status": "planned",
-  "designMode": "tiny-design",
-  "approvedOption": "Option A",
-  "designStatus": "approved",
-  "reviewStatus": "approved",
-  "spec": {
-    "primaryCapability": "cap-example",
-    "secondaryCapabilities": [],
-    "expectedDelta": [
-      "Tighten current truth for the capability"
-    ],
-    "affectedInvariants": [],
-    "gapsClosed": [],
-    "newGaps": [],
-    "specFiles": [
-      "devflow/specs/capabilities/cap-example.md"
-    ],
-    "syncStatus": "planned"
-  },
-  "tasteDecisions": [],
-  "userChallenges": [],
   "currentTaskId": "T001",
-  "activePhase": 1,
-  "frozenDecisions": [
-    "Keep the existing route and data contract",
-    "Prefer a minimal patch over a broader refactor"
-  ],
   "tasks": [
     {
       "id": "T001",
       "title": "[TEST] Add a failing test for the missing behavior",
+      "type": "TEST",
       "phase": 1,
-      "status": "pending",
-      "tddPhase": "red",
-      "verticalSlice": "Slice 1",
-      "testSeam": {
-        "entry": "public interface / caller flow / CLI / API / UI / trace replay / harness",
-        "behaviorAsserted": "The user or caller observable behavior that should exist",
-        "specStyleTestName": "caller can observe the required behavior",
-        "oneLogicalBehavior": true,
-        "publicVerificationPath": "Read back through the same public interface or user-visible path",
-        "implementationDetailRisk": "low"
-      },
-      "feedbackLoop": {
-        "type": "automated-test",
-        "determinism": "deterministic",
-        "expectedFailure": "Fails because the target behavior is missing"
-      },
-      "allowedMocks": [
-        "external API / time / randomness / filesystem / database boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Implement only the code needed to pass this Red behavior",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT/mark-task-complete.sh\" --manifest devflow/changes/REQ-XXX-short-name/planning/task-manifest.json --tasks devflow/changes/REQ-XXX-short-name/planning/tasks.md --task T001",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "shallow module",
-        "feature envy",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ],
-      "dependsOn": [],
       "parallel": false,
+      "dependsOn": [],
       "touches": [
         "tests",
         "requirement-behavior"
       ],
       "files": [
         "src/feature/feature.test.ts"
+      ],
+      "run": [
+        "npm test -- src/feature/feature.test.ts"
       ],
       "acceptance": [
         "The target behavior is reproduced as a failing test",
@@ -340,11 +123,31 @@
       "reviews": {
         "spec": "pending",
         "code": "pending"
-      }
+      },
+      "status": "pending",
+      "tddPhase": "red",
+      "verticalSlice": "Slice 1",
+      "testSeam": {
+        "entry": "public interface / caller flow / CLI / API / UI / trace replay / harness",
+        "behaviorAsserted": "The user or caller observable behavior that should exist",
+        "specStyleTestName": "caller can observe the required behavior",
+        "oneLogicalBehavior": true,
+        "publicVerificationPath": "Read back through the same public interface or user-visible path",
+        "implementationDetailRisk": "low"
+      },
+      "feedbackLoop": {
+        "type": "automated-test",
+        "determinism": "deterministic",
+        "expectedFailure": "Fails because the target behavior is missing"
+      },
+      "checks": [],
+      "attempts": 0,
+      "maxRetries": 1
     }
   ],
-  "openQuestions": [],
-  "deferredQuestions": [
-    "If the patch touches shared contracts, upgrade the design to full-design"
-  ]
+  "metadata": {
+    "source": "tasks.md",
+    "generatedBy": "skill:cc-plan",
+    "planVersion": 1
+  }
 }

--- a/.claude/skills/cc-plan/assets/TINY_DESIGN_TEMPLATE.md
+++ b/.claude/skills/cc-plan/assets/TINY_DESIGN_TEMPLATE.md
@@ -16,6 +16,13 @@
 - Primary capability:
 - Secondary capabilities:
 
+## Progressive Disclosure Index
+
+- Default read: Frozen Design Card, Validation, Main Risk, Approval.
+- Open for scope questions: Source Handoff, Capability Handoff, Implementation Surface Map.
+- Open for trust/conflict questions: Source Trust Boundary, External Document Conflicts, Domain Language & Decisions.
+- Open for audit/recovery: Review Gate, Bounded Review Loop, Decision Questions.
+
 ## Source Handoff
 
 - Why now:

--- a/.claude/skills/cc-plan/references/planning-contract.md
+++ b/.claude/skills/cc-plan/references/planning-contract.md
@@ -7,32 +7,33 @@
 3. 执行 handoff 必须写进 `planning/tasks.md` 顶部，不能依赖单独的 `context-package.md`。
 4. `planning/task-manifest.json` 必须和 `planning/tasks.md` 同步，且能告诉 `cc-do` 当前任务是谁。
 5. `planning/design.md`、`planning/tasks.md`、`planning/task-manifest.json` 必须记录来源版本链。
-6. 计划里出现 placeholder 词，就说明还没想清楚。
-7. 一次只推进一个澄清问题，不允许问题轰炸。
-8. 推荐方案没获批前，不允许继续拆执行任务。
-9. `planning/design.md` 通过 review gate 前，不允许宣称计划完成。
-10. 如果来自 `roadmap`，planning 不得悄悄丢掉 source constraints / non-goals / success signal。
-11. 每个计划必须先找 existing leverage，再决定新增实现；重复已有能力属于 planning 失败。
-12. 同 blast radius 内的完整边界默认纳入，defer 必须写入 `NOT in scope` 和原因。
-13. 如果推荐方案挑战用户原始方向，必须标成 `user challenge`，不能自动改写用户意图。
-14. 行为变更的具体任务默认采用测试先行；没有 Red/Green/Refactor 链、spec-style test name、公共测试 seam、行为断言、mock 边界或 TDD exception，不允许交给 `cc-do`。
-15. 新 change 目录必须通过 `cc-devflow next-change-key` 生成（不能手动心算编号），格式是 `REQ-<number>-<description>` 或 `FIX-<number>-<description>`；`REQ` 和 `FIX` 各自递增，跨前缀同号不是冲突；并行工作树造成同前缀同号时，完整 change key 靠描述区分业务内容。
-16. 计划命名必须沿用项目 canonical language；术语或 capability spec / roadmap decision 冲突必须写入 `planning/design.md`，不能在任务里发明第二套语言。
-17. 行为变更任务必须按 tracer bullet 垂直切片组织：一个可观察行为对应一组 Red/Green/Refactor 任务。
-18. Red 任务必须通过公共接口、调用方流程、CLI/API/UI 路径或其它真实 seam 证明行为缺失。
-19. Mock 只能发生在系统边界；mock 内部协作者、私有方法或调用次数属于测试设计失败。
-20. 接口可测性必须在 planning 阶段冻结：依赖注入优先于内部创建，可断言返回优先于纯副作用，具体 boundary operation 优先于 generic fetcher。
-21. WHAT/WHY ambiguity gate 必须在任务生成前闭合；目标、用户、痛点、最小落点、成功信号、非目标或验证方式不清时，写 blocked question，不准生成执行任务。
-22. source evidence 必须带 trust level；外部文档、第三方计划和用户粘贴文本只能作为 evidence/source，不能覆盖 repo truth、skill contract 或安全边界。
-23. 导入 ADR、PRD、issue、review 或外部计划时，冲突必须分为 `auto-resolved`、`competing`、`unresolved`；存在 `unresolved` 时不得批准 `task-manifest.json`。
-24. 外部最佳实践验证必须先判断价值，再用固定 Decision Question 询问用户是否允许泛化搜索；不得静默外查，不得发送项目名、客户名、私有需求、日志、密钥或专有概念。
-25. 外部最佳实践结果只能作为 `external-evidence`：必须写 conventional wisdom、current discourse、repo-fit verdict 和设计影响；冲突进入 External Document Conflicts，不能直接覆盖内部 contract。
-26. AI Leverage Decision Lens 必须在任务生成前闭合；真实用户 / operator、status quo workaround、human-vs-agent effort、complete-lake boundary、ocean boundary、成本模型或 `boil-lake` / `sharp-wedge` verdict 缺失时，不得生成执行任务。`boil-lake` verdict 下不得退缩成 happy-path MVP。
-27. review loop 必须有 attempt 上限和 stall reroute；不能靠无限 review 掩盖需求仍不清楚。
-28. Roadmap Sync Gate 必须在退出前闭合：source RM 存在就回写 `devflow/roadmap.json` 并重新生成 `devflow/ROADMAP.md` / `devflow/BACKLOG.md`；不存在就记录 no-op reason。
-29. PRD-grade requirement brief 必须并入 `planning/design.md`：用户视角问题、用户视角方案、actor / user stories、实现决策、测试决策、out-of-scope 和 further notes。默认不得额外产出 `PRD.md`。
-30. 需要用户判断时必须使用固定 Decision Question：`D<N>`、证据、推荐、2-3 个互斥的 `A/B/C` 字母选项、影响和 STOP 都必须出现；禁止用自由问句或 `1/2/3` 数字选项代替审批 gate。
-31. 所有用户决策必须写入 `planning/design.md` 的 `Decision Questions`，并同步到 `task-manifest.json.planningMeta.decisionQuestions`，不能只留在聊天里。
+6. 所有 SKILL 输出必须遵守 `docs/guides/artifact-contract.md`：状态只能有一个 owner，其它文件只能引用、投影或派生。
+7. 计划里出现 placeholder 词，就说明还没想清楚。
+8. 一次只推进一个澄清问题，不允许问题轰炸。
+9. 推荐方案没获批前，不允许继续拆执行任务。
+10. `planning/design.md` 通过 review gate 前，不允许宣称计划完成。
+11. 如果来自 `roadmap`，planning 不得悄悄丢掉 source constraints / non-goals / success signal。
+12. 每个计划必须先找 existing leverage，再决定新增实现；重复已有能力属于 planning 失败。
+13. 同 blast radius 内的完整边界默认纳入，defer 必须写入 `NOT in scope` 和原因。
+14. 如果推荐方案挑战用户原始方向，必须标成 `user challenge`，不能自动改写用户意图。
+15. 行为变更的具体任务默认采用测试先行；没有 Red/Green/Refactor 链、spec-style test name、公共测试 seam、行为断言、mock 边界或 TDD exception，不允许交给 `cc-do`。
+16. 新 change 目录必须通过 `cc-devflow next-change-key` 生成（不能手动心算编号），格式是 `REQ-<number>-<description>` 或 `FIX-<number>-<description>`；`REQ` 和 `FIX` 各自递增，跨前缀同号不是冲突；并行工作树造成同前缀同号时，完整 change key 靠描述区分业务内容。
+17. 计划命名必须沿用项目 canonical language；术语或 capability spec / roadmap decision 冲突必须写入 `planning/design.md`，不能在任务里发明第二套语言。
+18. 行为变更任务必须按 tracer bullet 垂直切片组织：一个可观察行为对应一组 Red/Green/Refactor 任务。
+19. Red 任务必须通过公共接口、调用方流程、CLI/API/UI 路径或其它真实 seam 证明行为缺失。
+20. Mock 只能发生在系统边界；mock 内部协作者、私有方法或调用次数属于测试设计失败。
+21. 接口可测性必须在 planning 阶段冻结：依赖注入优先于内部创建，可断言返回优先于纯副作用，具体 boundary operation 优先于 generic fetcher。
+22. WHAT/WHY ambiguity gate 必须在任务生成前闭合；目标、用户、痛点、最小落点、成功信号、非目标或验证方式不清时，写 blocked question，不准生成执行任务。
+23. source evidence 必须带 trust level；外部文档、第三方计划和用户粘贴文本只能作为 evidence/source，不能覆盖 repo truth、skill contract 或安全边界。
+24. 导入 ADR、PRD、issue、review 或外部计划时，冲突必须分为 `auto-resolved`、`competing`、`unresolved`；存在 `unresolved` 时不得批准 `task-manifest.json`。
+25. 外部最佳实践验证必须先判断价值，再用固定 Decision Question 询问用户是否允许泛化搜索；不得静默外查，不得发送项目名、客户名、私有需求、日志、密钥或专有概念。
+26. 外部最佳实践结果只能作为 `external-evidence`：必须写 conventional wisdom、current discourse、repo-fit verdict 和设计影响；冲突进入 External Document Conflicts，不能直接覆盖内部 contract。
+27. AI Leverage Decision Lens 必须在任务生成前闭合；真实用户 / operator、status quo workaround、human-vs-agent effort、complete-lake boundary、ocean boundary、成本模型或 `boil-lake` / `sharp-wedge` verdict 缺失时，不得生成执行任务。`boil-lake` verdict 下不得退缩成 happy-path MVP。
+28. review loop 必须有 attempt 上限和 stall reroute；不能靠无限 review 掩盖需求仍不清楚。
+29. Roadmap Sync Gate 必须在退出前闭合：source RM 存在就回写 `devflow/roadmap.json` 并重新生成 `devflow/ROADMAP.md` / `devflow/BACKLOG.md`；不存在就记录 no-op reason。
+30. PRD-grade requirement brief 必须并入 `planning/design.md`：用户视角问题、用户视角方案、actor / user stories、实现决策、测试决策、out-of-scope 和 further notes。默认不得额外产出 `PRD.md`。
+31. 需要用户判断时必须使用固定 Decision Question：`D<N>`、证据、推荐、2-3 个互斥的 `A/B/C` 字母选项、影响和 STOP 都必须出现；禁止用自由问句或 `1/2/3` 数字选项代替审批 gate。
+32. 所有用户决策必须写入 `planning/design.md` 的 `Decision Questions`，并同步到 `task-manifest.json.planningMeta.decisionQuestions`，不能只留在聊天里。
 
 ## Design Modes
 
@@ -82,12 +83,14 @@
 
 ## Execution Protocol Fields
 
-`planning/tasks.md` 必须有 `Execution Protocol` 区块，`planning/task-manifest.json` 必须有 `executionProtocol` 对象。它们共同约束 ClaudeCode / Codex：
+`planning/tasks.md` 必须有 `Execution Protocol` 区块。`planning/task-manifest.json` 不再复制这段协议；它只保留执行图和调度状态，避免把同一条 shell 命令复制进全局 metadata 和每个 task。
 
 - task 选择来自 `currentTaskId` 或 `select-ready-tasks.sh`
 - 每个 task 必须按模板字段完整展开，不能退化成标题清单
 - 完成 task 必须调用 `mark-task-complete.sh`
 - 脚本失败时修 evidence / checkpoint / review gate 后重跑，禁止手工绕过
+- completion command、required-before-completion 和 forbidden-shortcuts 写在 `planning/tasks.md` 的 task block；不得再写入 `task-manifest.json.executionProtocol` 或 `tasks[].completion`
+- `task-manifest.json` 不写顶层 `status`、`activePhase`、`sourceRoadmap` 或 `spec`；整体完成度从 `tasks[].status` 派生，phase 从任务图派生，roadmap/spec 状态从 `change-meta.json` 和 `devflow/roadmap.json` 读取。
 
 ## Decision Question Fields
 

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -1,17 +1,17 @@
 {
-  "updatedAt": "2026-05-10",
+  "updatedAt": "2026-05-11",
   "skills": {
     "cc-roadmap": "5.2.0",
     "cc-next": "1.0.0",
     "cc-dev": "1.0.0",
-    "cc-plan": "3.8.2",
-    "cc-investigate": "1.3.0",
-    "cc-do": "1.6.3",
+    "cc-plan": "3.8.3",
+    "cc-investigate": "1.3.1",
+    "cc-do": "1.6.4",
     "cc-review": "1.3.0",
     "cc-pr-review": "1.0.0",
     "cc-pr-land": "1.0.0",
     "cc-check": "1.10.1",
-    "cc-act": "1.8.3",
+    "cc-act": "1.8.4",
     "cc-spec-init": "1.1.0"
   },
   "examples": [

--- a/docs/examples/full-design-blocked/README.md
+++ b/docs/examples/full-design-blocked/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.2`, `cc-do@1.6.3`, `cc-check@1.10.1`
+- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.3`, `cc-do@1.6.4`, `cc-check@1.10.1`
 
 This example shows a requirement that **looked executable**, but `cc-check` correctly stopped it and sent it back to `cc-plan`.
 

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/design.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-002.v2`
 - Design version: `design.v2`
-- CC-Plan skill version: `3.8.2`
+- CC-Plan skill version: `3.8.3`
 - Requirement ID: `REQ-002`
 - Design mode: `full-design`
 - Why not `tiny-design`: the feature crosses import parsing, invite rules, billing limits, duplicate handling, and audit logging

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
@@ -6,63 +6,30 @@
   "requirementId": "REQ-002",
   "requirementVersion": "REQ-002.v2",
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.2",
+    "reqPlanSkillVersion": "3.8.3",
     "designVersion": "design.v2",
     "approvedAt": null,
-    "approvedBy": null,
     "basedOnOption": "Option B",
-    "requirementBrief": {
-      "problemStatement": "Admins onboarding larger teams need predictable bulk invite behavior for duplicates, invalid rows, and seat limits.",
-      "solutionSummary": "Freeze deterministic CSV row outcomes before executing the bulk invite flow.",
-      "actors": [
-        "workspace admin",
-        "support operator"
-      ],
-      "userStories": [
-        {
-          "id": "US-001",
-          "actor": "workspace admin",
-          "want": "upload a CSV of invite emails",
-          "benefit": "invite many collaborators without one-by-one entry",
-          "acceptance": [
-            "Mixed valid rows produce visible accepted outcomes"
-          ]
-        },
-        {
-          "id": "US-002",
-          "actor": "workspace admin",
-          "want": "see duplicate, invalid, and over-limit row states",
-          "benefit": "understand what happened without support help",
-          "acceptance": [
-            "Every skipped or rejected row has a reason"
-          ]
-        }
-      ],
-      "edgeOrRecoveryStories": [
-        {
-          "id": "US-EDGE-001",
-          "actor": "workspace admin",
-          "boundary": "CSV contains duplicates, invalid emails, or over-limit rows",
-          "desiredOutcome": "safe rows can proceed while bad rows are explained",
-          "acceptance": [
-            "Rule matrix covers duplicate, invalid, and seat-limit cases"
-          ]
-        }
-      ],
-      "implementationDecisions": [
-        "Freeze one row-outcome matrix before execution resumes"
-      ],
-      "testingDecisions": [
-        "Test row semantics through bulk-import rules and the admin upload flow"
-      ],
-      "outOfScope": [
-        "enterprise SCIM provisioning",
-        "background job redesign",
-        "rollback wizard for partial success"
-      ],
-      "furtherNotes": [
-        "Design remains blocked until duplicate and seat-limit semantics are approved"
-      ]
+    "aiLeverageDecisionLens": {
+      "realUserOrOperator": "workspace admin onboarding larger teams",
+      "statusQuoWorkaround": "paste invite emails one by one or track them in spreadsheets",
+      "humanTeamEffortForFullScope": "multiple weeks across product, engineering, billing, and support review",
+      "ccAgentEffortForFullScope": "several hours once row semantics are approved, but unbounded before that",
+      "aiCompressionRatio": "high after semantics freeze, low while the product contract is ambiguous",
+      "completeLakeBoundary": "row classification, admin upload flow, billing-seat checks, and audit mapping after rule approval",
+      "oceanBoundary": "SCIM, background retries, rollback wizard, and unspecified billing semantics",
+      "scopeRecommendation": "sharp-wedge",
+      "costModel": {
+        "agentTime": "medium after rule approval",
+        "humanReviewTime": "high until semantics are approved",
+        "verificationCost": "bulk rules, admin flow, billing, and audit tests",
+        "maintenanceCost": "medium after semantics freeze",
+        "failureCost": "high if billing or audit outcomes drift",
+        "reversibility": "limited once execution semantics ship"
+      },
+      "verdict": "sharp-wedge",
+      "missingEvidenceOrPivotReason": "none at plan approval; cc-check later reopened duplicate, invalid-row, partial-success, and seat-limit semantics before retry or cc-act",
+      "impactOnApprovedDirection": "allow bounded import-path execution, then block final proof if review finds row semantics drift"
     },
     "externalBestPractice": {
       "needed": true,
@@ -172,31 +139,9 @@
         "impact": "cc-do retry and cc-act must stay blocked until this is answered",
         "status": "asked"
       }
-    ],
-    "aiLeverageDecisionLens": {
-      "realUserOrOperator": "workspace admin onboarding larger teams",
-      "statusQuoWorkaround": "paste invite emails one by one or track them in spreadsheets",
-      "humanTeamEffortForFullScope": "multiple weeks across product, engineering, billing, and support review",
-      "ccAgentEffortForFullScope": "several hours once row semantics are approved, but unbounded before that",
-      "aiCompressionRatio": "high after semantics freeze, low while the product contract is ambiguous",
-      "completeLakeBoundary": "row classification, admin upload flow, billing-seat checks, and audit mapping after rule approval",
-      "oceanBoundary": "SCIM, background retries, rollback wizard, and unspecified billing semantics",
-      "scopeRecommendation": "sharp-wedge",
-      "costModel": {
-        "agentTime": "medium after rule approval",
-        "humanReviewTime": "high until semantics are approved",
-        "verificationCost": "bulk rules, admin flow, billing, and audit tests",
-        "maintenanceCost": "medium after semantics freeze",
-        "failureCost": "high if billing or audit outcomes drift",
-        "reversibility": "limited once execution semantics ship"
-      },
-      "verdict": "sharp-wedge",
-      "missingEvidenceOrPivotReason": "none at plan approval; cc-check later reopened duplicate, invalid-row, partial-success, and seat-limit semantics before retry or cc-act",
-      "impactOnApprovedDirection": "allow bounded import-path execution, then block final proof if review finds row semantics drift"
-    }
+    ]
   },
   "currentTaskId": null,
-  "activePhase": null,
   "tasks": [
     {
       "id": "T001",
@@ -260,46 +205,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": "Fails before the behavior exists"
-      },
-      "allowedMocks": [
-        "file upload boundary",
-        "billing / seat limit boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T001",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T002",
@@ -366,46 +272,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "file upload boundary",
-        "billing / seat limit boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Implement only the code needed to pass the current red behavior",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T002",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T003",
@@ -471,46 +338,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": "Fails before the behavior exists"
-      },
-      "allowedMocks": [
-        "file upload boundary",
-        "billing / seat limit boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T003",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T004",
@@ -577,46 +405,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "file upload boundary",
-        "billing / seat limit boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Implement only the code needed to pass the current red behavior",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T004",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T005",
@@ -687,85 +476,12 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "file upload boundary",
-        "billing / seat limit boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T005",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     }
   ],
   "metadata": {
     "source": "tasks.md",
     "generatedBy": "docs-example",
     "planVersion": 1
-  },
-  "executionProtocol": {
-    "templateCompliance": {
-      "required": true,
-      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
-      "taskBlockMustInclude": [
-        "Goal",
-        "TDD phase",
-        "Files",
-        "Read first",
-        "Verification",
-        "Evidence",
-        "Test seam",
-        "Public verification path",
-        "Allowed mocks",
-        "Completion"
-      ],
-      "titleOnlyTasks": "forbidden"
-    },
-    "selection": {
-      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/select-ready-tasks.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json"
-    },
-    "completion": {
-      "manualStatusEdit": "forbidden",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task <task-id>",
-      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
-      "updates": [
-        "planning/task-manifest.json.tasks[].status",
-        "planning/task-manifest.json.currentTaskId",
-        "planning/task-manifest.json.status",
-        "planning/tasks.md checkbox"
-      ]
-    }
   }
 }

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-002.v2`
 - Design version: `design.v2`
-- CC-Plan skill version: `3.8.2`
+- CC-Plan skill version: `3.8.3`
 - Source roadmap item: `RM-010`
 - Source roadmap version: `roadmap.v2`
 

--- a/docs/examples/local-handoff/README.md
+++ b/docs/examples/local-handoff/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.2`, `cc-do@1.6.3`, `cc-check@1.10.1`, `cc-act@1.8.3`
+- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.3`, `cc-do@1.6.4`, `cc-check@1.10.1`, `cc-act@1.8.4`
 
 This example shows verified work that is **ready to move forward**, but `cc-act` still chooses `local-handoff`.
 

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/design.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-003.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.2`
+- CC-Plan skill version: `3.8.3`
 - Requirement ID: `REQ-003`
 - Design mode: `tiny-design`
 - Why this stays `tiny-design`: the patch adds one export action inside the existing admin audit UI without changing data contracts

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
@@ -6,44 +6,30 @@
   "requirementId": "REQ-003",
   "requirementVersion": "REQ-003.v1",
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.2",
+    "reqPlanSkillVersion": "3.8.3",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-16T13:10:00.000Z",
-    "approvedBy": "user",
     "basedOnOption": "Tiny design card",
-    "requirementBrief": {
-      "problemStatement": "Admins can review audit summary rows in the UI, but weekly reporting requires manual copying.",
-      "solutionSummary": "Add a CSV download action for the currently visible audit summary rows.",
-      "actors": [
-        "workspace admin reviewing weekly activity"
-      ],
-      "userStories": [
-        {
-          "id": "US-001",
-          "actor": "workspace admin",
-          "want": "download visible audit summary rows as CSV",
-          "benefit": "include them in weekly reporting without manual copying",
-          "acceptance": [
-            "Panel behavior test proves the export action uses current summary rows"
-          ]
-        }
-      ],
-      "edgeOrRecoveryStories": [],
-      "implementationDecisions": [
-        "Export only rows already visible in the panel",
-        "Keep CSV as the only output format"
-      ],
-      "testingDecisions": [
-        "Test through the admin panel action and visible row data"
-      ],
-      "outOfScope": [
-        "JSON export",
-        "scheduled reporting",
-        "shared reporting backend"
-      ],
-      "furtherNotes": [
-        "Richer machine-readable exports should become a separate requirement"
-      ]
+    "aiLeverageDecisionLens": {
+      "realUserOrOperator": "workspace admin preparing weekly review notes",
+      "statusQuoWorkaround": "manual copy of visible audit rows",
+      "humanTeamEffortForFullScope": "about one day for an engineer to implement, test, and document the local export",
+      "ccAgentEffortForFullScope": "about 30 minutes for visible-row CSV export plus targeted test and lint",
+      "aiCompressionRatio": "roughly 10x for the bounded local export path",
+      "completeLakeBoundary": "visible-row CSV export, panel action, current data source, targeted panel test, and lint",
+      "oceanBoundary": "JSON export, scheduled reporting, shared reporting backend, and cross-panel reporting platform",
+      "scopeRecommendation": "boil-lake",
+      "costModel": {
+        "agentTime": "low",
+        "humanReviewTime": "low",
+        "verificationCost": "targeted panel test plus lint",
+        "maintenanceCost": "low while scoped to visible rows",
+        "failureCost": "admins keep copying rows manually",
+        "reversibility": "reversible UI action"
+      },
+      "verdict": "boil-lake",
+      "missingEvidenceOrPivotReason": "",
+      "impactOnApprovedDirection": "complete the local visible-row export lake while deferring reporting platform work"
     },
     "externalBestPractice": {
       "needed": false,
@@ -89,31 +75,9 @@
         "impact": "cc-do exports only visible rows from the current panel and avoids new reporting contracts",
         "status": "answered"
       }
-    ],
-    "aiLeverageDecisionLens": {
-      "realUserOrOperator": "workspace admin preparing weekly review notes",
-      "statusQuoWorkaround": "manual copy of visible audit rows",
-      "humanTeamEffortForFullScope": "about one day for an engineer to implement, test, and document the local export",
-      "ccAgentEffortForFullScope": "about 30 minutes for visible-row CSV export plus targeted test and lint",
-      "aiCompressionRatio": "roughly 10x for the bounded local export path",
-      "completeLakeBoundary": "visible-row CSV export, panel action, current data source, targeted panel test, and lint",
-      "oceanBoundary": "JSON export, scheduled reporting, shared reporting backend, and cross-panel reporting platform",
-      "scopeRecommendation": "boil-lake",
-      "costModel": {
-        "agentTime": "low",
-        "humanReviewTime": "low",
-        "verificationCost": "targeted panel test plus lint",
-        "maintenanceCost": "low while scoped to visible rows",
-        "failureCost": "admins keep copying rows manually",
-        "reversibility": "reversible UI action"
-      },
-      "verdict": "boil-lake",
-      "missingEvidenceOrPivotReason": "",
-      "impactOnApprovedDirection": "complete the local visible-row export lake while deferring reporting platform work"
-    }
+    ]
   },
   "currentTaskId": null,
-  "activePhase": null,
   "tasks": [
     {
       "id": "T001",
@@ -178,45 +142,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": "Fails before the behavior exists"
-      },
-      "allowedMocks": [
-        "download / blob boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T001",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T002",
@@ -283,45 +209,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "download / blob boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Implement only the code needed to pass the current red behavior",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T002",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T003",
@@ -392,84 +280,12 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "download / blob boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T003",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     }
   ],
   "metadata": {
     "source": "tasks.md",
     "generatedBy": "docs-example",
     "planVersion": 1
-  },
-  "executionProtocol": {
-    "templateCompliance": {
-      "required": true,
-      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
-      "taskBlockMustInclude": [
-        "Goal",
-        "TDD phase",
-        "Files",
-        "Read first",
-        "Verification",
-        "Evidence",
-        "Test seam",
-        "Public verification path",
-        "Allowed mocks",
-        "Completion"
-      ],
-      "titleOnlyTasks": "forbidden"
-    },
-    "selection": {
-      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/select-ready-tasks.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json"
-    },
-    "completion": {
-      "manualStatusEdit": "forbidden",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task <task-id>",
-      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
-      "updates": [
-        "planning/task-manifest.json.tasks[].status",
-        "planning/task-manifest.json.currentTaskId",
-        "planning/task-manifest.json.status",
-        "planning/tasks.md checkbox"
-      ]
-    }
   }
 }

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-003.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.2`
+- CC-Plan skill version: `3.8.3`
 - Source roadmap item: `RM-020`
 - Source roadmap version: `roadmap.v3`
 

--- a/docs/examples/pdca-loop/README.md
+++ b/docs/examples/pdca-loop/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.2`, `cc-do@1.6.3`, `cc-check@1.10.1`, `cc-act@1.8.3`
+- Bound skills: `cc-roadmap@5.2.0`, `cc-plan@3.8.3`, `cc-do@1.6.4`, `cc-check@1.10.1`, `cc-act@1.8.4`
 
 This folder shows one minimal but complete `cc-roadmap -> cc-plan -> cc-do -> cc-check -> cc-act` loop.
 

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/design.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/design.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-001.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.2`
+- CC-Plan skill version: `3.8.3`
 - Requirement ID: `REQ-001`
 - Design mode: `tiny-design`
 - Why this stays `tiny-design`: the patch is limited to an existing dialog and test file, with no API or data model changes

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json
@@ -3,63 +3,33 @@
   "goal": "Add a one-click copy action to the existing share dialog without changing backend contracts.",
   "createdAt": "2026-04-15T10:00:00.000Z",
   "updatedAt": "2026-04-15T11:10:00.000Z",
-  "status": "verified",
   "requirementId": "REQ-001",
   "requirementVersion": "REQ-001.v1",
-  "sourceRoadmap": {
-    "itemId": "RM-001",
-    "roadmapVersion": "roadmap.v1",
-    "roadmapSkillVersion": "5.2.0",
-    "sourceStage": "Stage 1",
-    "successSignal": "Users can copy the invite link with one click",
-    "killSignal": "The patch requires backend or permission changes",
-    "dependencies": [
-      "Existing share dialog stays intact"
-    ],
-    "nonGoals": [
-      "No invite role redesign",
-      "No share analytics"
-    ]
-  },
   "planningMeta": {
-    "reqPlanSkillVersion": "3.8.2",
+    "reqPlanSkillVersion": "3.8.3",
     "designVersion": "design.v1",
     "approvedAt": "2026-04-15T10:05:00.000Z",
-    "approvedBy": "user",
     "basedOnOption": "Tiny design card",
-    "requirementBrief": {
-      "problemStatement": "Users can see the invite URL, but copying it still requires manual selection.",
-      "solutionSummary": "Add a one-click copy action with lightweight confirmation inside the existing share dialog.",
-      "actors": [
-        "workspace member sharing an invite"
-      ],
-      "userStories": [
-        {
-          "id": "US-001",
-          "actor": "workspace member",
-          "want": "copy the invite link with one click",
-          "benefit": "share it without manually selecting text",
-          "acceptance": [
-            "Dialog behavior test proves the current invite URL is copied"
-          ]
-        }
-      ],
-      "edgeOrRecoveryStories": [],
-      "implementationDecisions": [
-        "Reuse the existing invite URL source and dialog props"
-      ],
-      "testingDecisions": [
-        "Test through the share dialog behavior, not an internal helper"
-      ],
-      "outOfScope": [
-        "invite generation",
-        "role controls",
-        "analytics",
-        "clipboard fallback redesign"
-      ],
-      "furtherNotes": [
-        "Richer copied-state feedback is a separate UX requirement"
-      ]
+    "aiLeverageDecisionLens": {
+      "realUserOrOperator": "workspace member sharing an invite",
+      "statusQuoWorkaround": "manual selection and copy of the visible invite URL",
+      "humanTeamEffortForFullScope": "about half a day for one engineer including test and review",
+      "ccAgentEffortForFullScope": "about 20 minutes for a targeted UI patch plus test update",
+      "aiCompressionRatio": "roughly 10x for this bounded UI slice",
+      "completeLakeBoundary": "copy action, current invite URL source, copied-state feedback, and dialog behavior test",
+      "oceanBoundary": "invite generation, permissions, analytics, or clipboard fallback redesign",
+      "scopeRecommendation": "boil-lake",
+      "costModel": {
+        "agentTime": "low",
+        "humanReviewTime": "low",
+        "verificationCost": "targeted dialog test",
+        "maintenanceCost": "low while scoped to the dialog",
+        "failureCost": "sharing friction remains",
+        "reversibility": "reversible UI patch"
+      },
+      "verdict": "boil-lake",
+      "missingEvidenceOrPivotReason": "",
+      "impactOnApprovedDirection": "cover the full same-dialog copy lake instead of only a happy-path button render"
     },
     "externalBestPractice": {
       "needed": false,
@@ -105,31 +75,9 @@
         "impact": "cc-do keeps implementation inside the share dialog and avoids backend or permission work",
         "status": "answered"
       }
-    ],
-    "aiLeverageDecisionLens": {
-      "realUserOrOperator": "workspace member sharing an invite",
-      "statusQuoWorkaround": "manual selection and copy of the visible invite URL",
-      "humanTeamEffortForFullScope": "about half a day for one engineer including test and review",
-      "ccAgentEffortForFullScope": "about 20 minutes for a targeted UI patch plus test update",
-      "aiCompressionRatio": "roughly 10x for this bounded UI slice",
-      "completeLakeBoundary": "copy action, current invite URL source, copied-state feedback, and dialog behavior test",
-      "oceanBoundary": "invite generation, permissions, analytics, or clipboard fallback redesign",
-      "scopeRecommendation": "boil-lake",
-      "costModel": {
-        "agentTime": "low",
-        "humanReviewTime": "low",
-        "verificationCost": "targeted dialog test",
-        "maintenanceCost": "low while scoped to the dialog",
-        "failureCost": "sharing friction remains",
-        "reversibility": "reversible UI patch"
-      },
-      "verdict": "boil-lake",
-      "missingEvidenceOrPivotReason": "",
-      "impactOnApprovedDirection": "cover the full same-dialog copy lake instead of only a happy-path button render"
-    }
+    ]
   },
   "currentTaskId": null,
-  "activePhase": null,
   "tasks": [
     {
       "id": "T001",
@@ -194,45 +142,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": "Fails before the behavior exists"
-      },
-      "allowedMocks": [
-        "clipboard boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T001",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T002",
@@ -299,45 +209,7 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "clipboard boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Implement only the code needed to pass the current red behavior",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T002",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     },
     {
       "id": "T003",
@@ -408,87 +280,12 @@
         "type": "automated-test",
         "determinism": "deterministic",
         "expectedFailure": ""
-      },
-      "allowedMocks": [
-        "clipboard boundary"
-      ],
-      "testQuality": {
-        "usesPublicInterface": true,
-        "describesBehavior": true,
-        "specStyleName": true,
-        "oneLogicalBehavior": true,
-        "verifiesThroughPublicPath": true,
-        "survivesInternalRefactor": true,
-        "mocksOnlySystemBoundaries": true,
-        "noBulkRed": true
-      },
-      "greenMinimality": {
-        "guard": "Keep the task scoped to its stated verification evidence",
-        "noSpeculativeBranches": true
-      },
-      "completion": {
-        "command": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T003",
-        "requiredBeforeCompletion": [
-          "verification evidence captured",
-          "checkpoint written",
-          "spec review gate recorded",
-          "code review gate recorded"
-        ],
-        "forbiddenShortcuts": [
-          "manual checkbox edit",
-          "manual manifest status edit",
-          "leaving currentTaskId stale"
-        ]
-      },
-      "refactorCandidates": [
-        "duplication",
-        "long method",
-        "primitive obsession",
-        "naming",
-        "more than three nested branches"
-      ]
+      }
     }
   ],
   "metadata": {
     "source": "tasks.md",
     "generatedBy": "docs-example",
     "planVersion": 1
-  },
-  "deferredQuestions": [
-    "If users still miss the copied-state confirmation, open RM-002 for richer feedback."
-  ],
-  "executionProtocol": {
-    "templateCompliance": {
-      "required": true,
-      "sourceTemplate": "assets/TASKS_TEMPLATE.md",
-      "taskBlockMustInclude": [
-        "Goal",
-        "TDD phase",
-        "Files",
-        "Read first",
-        "Verification",
-        "Evidence",
-        "Test seam",
-        "Public verification path",
-        "Allowed mocks",
-        "Completion"
-      ],
-      "titleOnlyTasks": "forbidden"
-    },
-    "selection": {
-      "sourceOfTruth": "planning/task-manifest.json.currentTaskId",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/select-ready-tasks.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json"
-    },
-    "completion": {
-      "manualStatusEdit": "forbidden",
-      "commandTemplate": "SCRIPT_ROOT=\".claude/skills/cc-do/scripts\"; if [[ ! -d \"$SCRIPT_ROOT\" && -d \".codex/skills/cc-do/scripts\" ]]; then SCRIPT_ROOT=\".codex/skills/cc-do/scripts\"; fi; bash \"$SCRIPT_ROOT\"/mark-task-complete.sh --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task <task-id>",
-      "failurePolicy": "Do not hand-edit status; fix missing checkpoint, review gate, or dependency evidence and rerun the script.",
-      "updates": [
-        "planning/task-manifest.json.tasks[].status",
-        "planning/task-manifest.json.currentTaskId",
-        "planning/task-manifest.json.status",
-        "planning/tasks.md checkbox"
-      ]
-    }
   }
 }

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
@@ -4,7 +4,7 @@
 
 - Requirement version: `REQ-001.v1`
 - Design version: `design.v1`
-- CC-Plan skill version: `3.8.2`
+- CC-Plan skill version: `3.8.3`
 - Source roadmap item: `RM-001`
 - Source roadmap version: `roadmap.v1`
 

--- a/docs/examples/scripts/check-example-bindings.sh
+++ b/docs/examples/scripts/check-example-bindings.sh
@@ -100,12 +100,16 @@ while IFS= read -r encoded; do
   assert_contains "$planning_dir/tasks.md" "- CC-Plan skill version: \`$REQ_PLAN_VERSION\`"
 
   jq -er --arg roadmap "$ROADMAP_VERSION" --arg reqplan "$REQ_PLAN_VERSION" '
-    (.sourceRoadmap.roadmapSkillVersion // $roadmap) == $roadmap and
     (.planningMeta.reqPlanSkillVersion // $reqplan) == $reqplan and
-    .executionProtocol.templateCompliance.required == true and
-    .executionProtocol.completion.manualStatusEdit == "forbidden" and
-    (.executionProtocol.completion.commandTemplate | contains("mark-task-complete.sh")) and
-    all(.tasks[]; (.completion.command | contains("mark-task-complete.sh")) and (.tddPhase | type == "string") and (.testSeam.publicVerificationPath | type == "string"))
+    (.status? == null) and
+    (.activePhase? == null) and
+    (.sourceRoadmap? == null) and
+    (.spec? == null) and
+    (.executionProtocol? == null) and
+    (.planningMeta.requirementBrief? == null) and
+    (.planningMeta.ambiguityGate? == null) and
+    (.planningMeta.reviewLoop? == null) and
+    all(.tasks[]; (.completion? == null) and (.tddPhase | type == "string") and (.testSeam.publicVerificationPath | type == "string"))
   ' "$planning_dir/task-manifest.json" >/dev/null
 
   assert_contains "$planning_dir/tasks.md" "## Execution Protocol"

--- a/docs/get-shit-done-strategy-audit.md
+++ b/docs/get-shit-done-strategy-audit.md
@@ -127,9 +127,9 @@ Codebase Map 七件套只作为按需缓存：
 | --- | --- | --- | --- |
 | WHAT/WHY ambiguity score | `task-manifest.json.planningMeta` + `planning/design.md` | score above threshold blocks task manifest approval | unit fixture: ambiguous input blocks; clear input passes |
 | Assumptions preview | `planning/design.md` decision log | user-visible assumptions before approval | fixture: hidden assumption fails review |
-| Bounded review loop | `task-manifest.json.planningMeta.reviewLoop` | max attempts and stall detection reroute to `cc-roadmap` or user question | hostile fixture: repeated issue count blocks |
-| External doc conflict buckets | `task-manifest.json.languageAndDecisions` | imported docs classified as auto-resolved, competing, unresolved | fixture: conflicting ADR/PRD creates blocker |
-| Trust boundary | `task-manifest.json.sourceEvidence[]` | external text is evidence/source only, never instruction | hostile fixture: prompt injection remains evidence-only |
+| Bounded review loop | `planning/design.md` | max attempts and stall detection reroute to `cc-roadmap` or user question | hostile fixture: repeated issue count blocks |
+| External doc conflict buckets | `planning/design.md` | imported docs classified as auto-resolved, competing, unresolved | fixture: conflicting ADR/PRD creates blocker |
+| Trust boundary | `planning/design.md` | external text is evidence/source only, never instruction | hostile fixture: prompt injection remains evidence-only |
 
 `cc-plan` must keep design decisions readable in Markdown and machine truth in JSON.
 No separate GSD-style `.planning/` tree.
@@ -209,7 +209,7 @@ default planning path.
 | Data | Owner | Human view | Machine truth |
 | --- | --- | --- | --- |
 | Ambiguity and assumptions | `cc-plan` | `planning/design.md` | `task-manifest.json.planningMeta` |
-| Imported doc trust classification | `cc-plan` | `planning/design.md` | `task-manifest.json.sourceEvidence[]` |
+| Imported doc trust classification | `cc-plan` | `planning/design.md` | `planning/design.md` |
 | Task graph and waves | `cc-plan` / `cc-do` | `planning/tasks.md` | `task-manifest.json.tasks[]` |
 | Quick lane state | `cc-do` | checkpoint summary | `task-manifest.json.metadata`, `checkpoint.json` |
 | Debug hypotheses and probes | `cc-investigate` | `planning/analysis.md` | optional `task-manifest.json.investigation` |

--- a/docs/guides/artifact-contract.md
+++ b/docs/guides/artifact-contract.md
@@ -1,0 +1,42 @@
+# Artifact Contract
+
+cc-devflow artifacts follow two rules: progressive disclosure and one state owner.
+
+## Progressive Disclosure
+
+Every skill output should have a default path and deeper layers.
+
+- Default layer: the next actor can see the current state, next action, and proof source quickly.
+- Conditional layer: open only when scope, dependency, review, or conflict questions arise.
+- Deep layer: full evidence, reasoning, or historical review, opened only for audit or recovery.
+
+If a field has no clear opener and no downstream consumer, remove it.
+
+## State Owners
+
+| State | Owner artifact | Projection / derived readers |
+| --- | --- | --- |
+| Roadmap item status and progress | `devflow/roadmap.json` | `devflow/ROADMAP.md`, `devflow/BACKLOG.md`, handoff summaries |
+| Capability/spec sync state | `devflow/changes/<change-key>/change-meta.json` | `planning/tasks.md`, `review/report-card.json`, handoff summaries |
+| Execution task status | `planning/task-manifest.json.tasks[].status` | `planning/tasks.md` checkboxes, recovery summaries |
+| Ready task / phase | derived from `tasks[].status`, `tasks[].phase`, and `tasks[].dependsOn` | `currentTaskId` cache, ready-task selector output |
+| Runtime checkpoint state | `execution/tasks/<task-id>/checkpoint.json` | `events.jsonl`, recovery summaries |
+| Review verdict | `review/report-card.json.verdict` | PR brief, release note, act gate |
+| PR / remote queue truth | live GitHub API / `gh` output | local review notes and handoff summaries |
+
+## Duplication Rules
+
+- Machine artifacts may reference another owner by id or path, but must not copy its status lifecycle.
+- Markdown projections must state their source instead of becoming editable truth.
+- Derived fields must be described as derived/cache and must be recomputable.
+- A skill must not create a new status field unless it also names the owner, lifecycle, projection readers, and validation gate.
+- Task manifests must not duplicate PRD narrative, review-loop prose, source-trust details, completion shell commands, roadmap progress, or spec sync status.
+
+## Required Check
+
+Before changing any skill output, answer:
+
+1. Who owns this state?
+2. Is this field consumed directly, or is it a projection?
+3. Can it be recomputed from a stronger source?
+4. What validation fails if this state diverges?

--- a/lib/skill-runtime/__tests__/planner.tdd.test.js
+++ b/lib/skill-runtime/__tests__/planner.tdd.test.js
@@ -120,7 +120,7 @@ describe('TDD Order Validation', () => {
       });
     });
 
-    test('should write currentTaskId and activePhase into manifest', async () => {
+    test('should write currentTaskId while deriving activePhase from the task graph', async () => {
       const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-devflow-planner-'));
       const changeId = 'REQ-321';
       const tasksPath = path.join(repoRoot, 'devflow', 'changes', `${changeId}-change`, 'planning', 'tasks.md');
@@ -146,7 +146,7 @@ describe('TDD Order Validation', () => {
         overwrite: true
       });
 
-      expect(manifest.activePhase).toBe(1);
+      expect(manifest.activePhase).toBeUndefined();
       expect(manifest.currentTaskId).toBe('T002');
       expect(manifest.tasks[1].reviews).toEqual({ spec: 'pending', code: 'pending' });
     });

--- a/lib/skill-runtime/__tests__/schemas.test.js
+++ b/lib/skill-runtime/__tests__/schemas.test.js
@@ -8,7 +8,6 @@ describe('Manifest schema hard constraints', () => {
       createdAt: '2026-04-10T01:00:00.000Z',
       updatedAt: '2026-04-10T01:05:00.000Z',
       currentTaskId: 'T001',
-      activePhase: 1,
       tasks: [
         {
           id: 'T001',
@@ -73,7 +72,39 @@ describe('Manifest schema hard constraints', () => {
     });
 
     expect(manifest.currentTaskId).toBe('T001');
-    expect(manifest.activePhase).toBe(1);
+    expect(manifest.activePhase).toBeUndefined();
+  });
+
+  test('accepts legacy activePhase input without preserving the retired field', () => {
+    const manifest = parseManifest({
+      changeId: 'REQ-560',
+      goal: 'Validate legacy manifest compatibility',
+      createdAt: '2026-04-10T01:00:00.000Z',
+      updatedAt: '2026-04-10T01:05:00.000Z',
+      currentTaskId: 'T001',
+      activePhase: 1,
+      tasks: [
+        {
+          id: 'T001',
+          title: '[TEST] Counter behavior',
+          type: 'OTHER',
+          phase: 1,
+          dependsOn: [],
+          run: ['echo ok'],
+          status: 'pending',
+          attempts: 0,
+          maxRetries: 1
+        }
+      ],
+      metadata: {
+        source: 'default',
+        generatedBy: 'test',
+        planVersion: 1
+      }
+    });
+
+    expect(manifest.currentTaskId).toBe('T001');
+    expect(manifest.activePhase).toBeUndefined();
   });
 
   test('rejects invalid currentTaskId for tasks.md manifest', () => {

--- a/lib/skill-runtime/planner.js
+++ b/lib/skill-runtime/planner.js
@@ -480,7 +480,7 @@ function deriveManifestExecutionState(tasks) {
 function applyManifestExecutionState(manifest, updatedAt = nowIso()) {
   const executionState = deriveManifestExecutionState(manifest.tasks || []);
   manifest.currentTaskId = executionState.currentTaskId;
-  manifest.activePhase = executionState.activePhase;
+  delete manifest.activePhase;
   manifest.updatedAt = updatedAt;
   return manifest;
 }
@@ -504,7 +504,6 @@ async function createTaskManifest({ repoRoot, changeId, goal, overwrite = false 
     createdAt: previous?.createdAt || nowIso(),
     updatedAt: nowIso(),
     currentTaskId: null,
-    activePhase: null,
     tasks,
     metadata: {
       source: hasTasksFile ? 'tasks.md' : 'default',

--- a/lib/skill-runtime/query.js
+++ b/lib/skill-runtime/query.js
@@ -81,7 +81,7 @@ async function getNextTask(repoRoot, changeId, options = {}) {
   const manifestPath = getTaskManifestPath(repoRoot, changeId, options);
   const manifest = await readQueryArtifact(manifestPath);
   const executionState = deriveManifestExecutionState(manifest.tasks || []);
-  const activePhase = manifest.activePhase ?? executionState.activePhase;
+  const activePhase = executionState.activePhase;
   const completedIds = new Set(
     (manifest.tasks || [])
       .filter((task) => isTaskCompletedStatus(task.status))

--- a/lib/skill-runtime/schemas.js
+++ b/lib/skill-runtime/schemas.js
@@ -107,7 +107,7 @@ const ManifestSchema = z.object({
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   currentTaskId: z.string().regex(TASK_ID_PATTERN).nullable().default(null),
-  activePhase: z.number().int().min(1).nullable().default(null),
+  activePhase: z.number().int().min(1).nullable().optional(),
   tasks: z.array(TaskSchema),
   metadata: z.object({
     source: z.enum(['tasks.md', 'default']).default('default'),
@@ -161,7 +161,7 @@ const ManifestSchema = z.object({
     ? Math.min(...unfinished.map((task) => task.phase || 1))
     : null;
 
-  if (manifest.activePhase !== null && manifest.activePhase !== derivedActivePhase) {
+  if (manifest.activePhase !== undefined && manifest.activePhase !== null && manifest.activePhase !== derivedActivePhase) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['activePhase'],
@@ -542,7 +542,9 @@ function parseWithSchema(schema, input, label) {
 }
 
 function parseManifest(input) {
-  return parseWithSchema(ManifestSchema, input, 'Manifest');
+  const manifest = parseWithSchema(ManifestSchema, input, 'Manifest');
+  delete manifest.activePhase;
+  return manifest;
 }
 
 function parseCheckpoint(input) {

--- a/scripts/validate-publish.js
+++ b/scripts/validate-publish.js
@@ -321,6 +321,61 @@ function collectExternalBestPracticeErrors(manifest, label, errors) {
   }
 }
 
+const RETIRED_CC_PLAN_MANIFEST_FIELDS = [
+  'status',
+  'activePhase',
+  'sourceRoadmap',
+  'spec',
+  'executionProtocol',
+  'sourceEvidence',
+  'languageAndDecisions',
+  'executionDiscipline',
+  'approvedOption',
+  'designStatus',
+  'reviewStatus',
+  'tasteDecisions',
+  'userChallenges',
+  'frozenDecisions',
+  'deferredQuestions'
+];
+
+const RETIRED_CC_PLAN_META_FIELDS = [
+  'requirementBrief',
+  'ambiguityGate',
+  'reviewLoop',
+  'approvedBy'
+];
+
+const RETIRED_CC_PLAN_TASK_FIELDS = [
+  'completion',
+  'testQuality',
+  'allowedMocks',
+  'greenMinimality',
+  'refactorCandidates'
+];
+
+function collectSlimManifestErrors(manifest, label, errors) {
+  for (const field of RETIRED_CC_PLAN_MANIFEST_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(manifest || {}, field)) {
+      errors.push(`${label}.${field} is retired; keep that detail in planning/design.md or planning/tasks.md`);
+    }
+  }
+
+  for (const field of RETIRED_CC_PLAN_META_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(manifest?.planningMeta || {}, field)) {
+      errors.push(`${label}.planningMeta.${field} is retired; keep that detail in planning/design.md`);
+    }
+  }
+
+  (manifest?.tasks || []).forEach((task, index) => {
+    for (const field of RETIRED_CC_PLAN_TASK_FIELDS) {
+      if (Object.prototype.hasOwnProperty.call(task || {}, field)) {
+        errors.push(`${label}.tasks[${index}].${field} is retired; keep that detail in planning/tasks.md`);
+      }
+    }
+  });
+}
+
 function validateCcPlanPlanningContracts(errors) {
   const skill = fs.readFileSync(path.join(ROOT, '.claude/skills/cc-plan/SKILL.md'), 'utf8');
   const fullDesign = fs.readFileSync(path.join(ROOT, '.claude/skills/cc-plan/assets/DESIGN_TEMPLATE.md'), 'utf8');
@@ -366,15 +421,9 @@ function validateCcPlanPlanningContracts(errors) {
 
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   const currentPlanVersion = readSkillVersion('cc-plan');
-  const currentRoadmapVersion = readSkillVersion('cc-roadmap');
   if (manifest?.planningMeta?.reqPlanSkillVersion !== currentPlanVersion) {
     errors.push(
       `cc-plan TASK_MANIFEST_TEMPLATE.json planningMeta.reqPlanSkillVersion must be ${currentPlanVersion}`
-    );
-  }
-  if (manifest?.sourceRoadmap?.roadmapSkillVersion !== currentRoadmapVersion) {
-    errors.push(
-      `cc-plan TASK_MANIFEST_TEMPLATE.json sourceRoadmap.roadmapSkillVersion must be ${currentRoadmapVersion}`
     );
   }
   if (!manifest?.planningMeta?.aiLeverageDecisionLens) {
@@ -383,6 +432,11 @@ function validateCcPlanPlanningContracts(errors) {
   if (!Object.prototype.hasOwnProperty.call(manifest?.planningMeta?.aiLeverageDecisionLens || {}, 'completeLakeBoundary')) {
     errors.push('cc-plan TASK_MANIFEST_TEMPLATE.json missing planningMeta.aiLeverageDecisionLens.completeLakeBoundary');
   }
+  collectSlimManifestErrors(
+    manifest,
+    '.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json',
+    errors
+  );
 
   collectDecisionQuestionOptionErrors(
     manifest,
@@ -418,7 +472,40 @@ function validateCcPlanPlanningContracts(errors) {
         path.relative(ROOT, exampleManifestPath),
         errors
       );
+      collectSlimManifestErrors(
+        JSON.parse(fs.readFileSync(exampleManifestPath, 'utf8')),
+        path.relative(ROOT, exampleManifestPath),
+        errors
+      );
     }
+  }
+}
+
+function validateArtifactOwnershipContracts(errors) {
+  ensurePath('docs/guides/artifact-contract.md', 'file', errors);
+  const contract = fs.readFileSync(path.join(ROOT, 'docs/guides/artifact-contract.md'), 'utf8');
+  for (const snippet of [
+    '## Progressive Disclosure',
+    '## State Owners',
+    'Task manifests must not duplicate PRD narrative',
+    'Who owns this state?'
+  ]) {
+    if (!contract.includes(snippet)) {
+      errors.push(`docs/guides/artifact-contract.md missing artifact contract snippet: ${snippet}`);
+    }
+  }
+
+  const manifestTemplates = [
+    '.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json',
+    '.claude/skills/cc-investigate/assets/TASK_MANIFEST_TEMPLATE.json'
+  ];
+
+  for (const relPath of manifestTemplates) {
+    collectSlimManifestErrors(
+      JSON.parse(fs.readFileSync(path.join(ROOT, relPath), 'utf8')),
+      relPath,
+      errors
+    );
   }
 }
 
@@ -801,6 +888,7 @@ function main() {
   validateInventoryParity(errors);
   validateCcRoadmapContracts(errors);
   validateCcPlanPlanningContracts(errors);
+  validateArtifactOwnershipContracts(errors);
   validatePublicSkillContracts(errors);
   validateExampleBindings(errors);
   validatePackTarball(errors);
@@ -823,5 +911,7 @@ if (require.main === module) {
 module.exports = {
   collectDecisionQuestionOptionErrors,
   collectExternalBestPracticeErrors,
+  collectSlimManifestErrors,
+  validateArtifactOwnershipContracts,
   ensureStringArray
 };

--- a/test/validate-publish.test.js
+++ b/test/validate-publish.test.js
@@ -5,6 +5,8 @@ const { spawnSync } = require('child_process');
 const {
   collectDecisionQuestionOptionErrors,
   collectExternalBestPracticeErrors,
+  collectSlimManifestErrors,
+  validateArtifactOwnershipContracts,
   ensureStringArray
 } = require('../scripts/validate-publish');
 
@@ -192,16 +194,68 @@ describe('validate-publish', () => {
     expect(manifest).toContain('"aiLeverageDecisionLens"');
     expect(manifest).toContain('"humanTeamEffortForFullScope"');
     expect(manifest).toContain('"completeLakeBoundary"');
-    expect(parsedManifest.planningMeta.reqPlanSkillVersion).toBe('3.8.2');
-    expect(parsedManifest.sourceRoadmap.roadmapSkillVersion).toBe('5.2.0');
+    expect(parsedManifest.planningMeta.reqPlanSkillVersion).toBe('3.8.3');
+    expect(parsedManifest.sourceRoadmap).toBeUndefined();
+    expect(parsedManifest.spec).toBeUndefined();
+    expect(parsedManifest.status).toBeUndefined();
+    expect(parsedManifest.activePhase).toBeUndefined();
     expect(planningContract).toContain('AI Leverage Decision Lens 必须在任务生成前闭合');
     expect(skill).toContain('## ClaudeCode / Codex Execution Compliance');
     expect(tasks).toContain('## Execution Protocol');
     expect(tasks).toContain('mark-task-complete.sh');
-    expect(parsedManifest.executionProtocol.templateCompliance.required).toBe(true);
-    expect(parsedManifest.executionProtocol.completion.manualStatusEdit).toBe('forbidden');
-    expect(parsedManifest.tasks[0].completion.command).toContain('mark-task-complete.sh');
+    expect(parsedManifest.executionProtocol).toBeUndefined();
+    expect(parsedManifest.tasks[0].completion).toBeUndefined();
+    expect(parsedManifest.tasks[0].run).toContain('npm test -- src/feature/feature.test.ts');
     expect(planningContract).toContain('## Execution Protocol Fields');
+  });
+
+  test('rejects retired cc-plan manifest fields', () => {
+    const errors = [];
+
+    collectSlimManifestErrors({
+      executionProtocol: {},
+      sourceEvidence: [],
+      sourceRoadmap: {},
+      spec: {},
+      status: 'planned',
+      activePhase: 1,
+      planningMeta: {
+        requirementBrief: {},
+        ambiguityGate: {},
+        reviewLoop: {}
+      },
+      tasks: [
+        {
+          id: 'T001',
+          completion: {},
+          testQuality: {},
+          allowedMocks: []
+        }
+      ]
+    }, 'manifest', errors);
+
+    expect(errors).toEqual(expect.arrayContaining([
+      'manifest.executionProtocol is retired; keep that detail in planning/design.md or planning/tasks.md',
+      'manifest.sourceEvidence is retired; keep that detail in planning/design.md or planning/tasks.md',
+      'manifest.sourceRoadmap is retired; keep that detail in planning/design.md or planning/tasks.md',
+      'manifest.spec is retired; keep that detail in planning/design.md or planning/tasks.md',
+      'manifest.status is retired; keep that detail in planning/design.md or planning/tasks.md',
+      'manifest.activePhase is retired; keep that detail in planning/design.md or planning/tasks.md',
+      'manifest.planningMeta.requirementBrief is retired; keep that detail in planning/design.md',
+      'manifest.planningMeta.ambiguityGate is retired; keep that detail in planning/design.md',
+      'manifest.planningMeta.reviewLoop is retired; keep that detail in planning/design.md',
+      'manifest.tasks[0].completion is retired; keep that detail in planning/tasks.md',
+      'manifest.tasks[0].testQuality is retired; keep that detail in planning/tasks.md',
+      'manifest.tasks[0].allowedMocks is retired; keep that detail in planning/tasks.md'
+    ]));
+  });
+
+  test('carries the shared artifact ownership contract', () => {
+    const errors = [];
+
+    validateArtifactOwnershipContracts(errors);
+
+    expect(errors).toEqual([]);
   });
 
   test('cc-roadmap carries the AI leverage route lens contract', () => {


### PR DESCRIPTION
## Summary
- add a shared artifact ownership contract with progressive disclosure and one-owner state rules
- slim cc-plan and cc-investigate manifests so execution graphs no longer duplicate roadmap/spec/status/protocol narrative
- update cc-do/cc-act to read roadmap/spec truth from change-meta and add publish/example gates for retired manifest fields

## Test Plan
- [x] npm test -- --runInBand
- [x] node scripts/validate-publish.js
- [x] bash docs/examples/scripts/check-example-bindings.sh
- [x] git diff --check