### PR TITLE
feat(runtime): stop generating execution process files

### DIFF
--- a/.claude/skills/cc-act/SKILL.md
+++ b/.claude/skills/cc-act/SKILL.md
@@ -76,7 +76,7 @@ reroutes:
     target: cc-do
 recovery_modes:
   - name: memory-consolidation
-    when: Delivery evidence is scattered across checkpoints, reviews, and prior handoff notes.
+    when: Delivery evidence is scattered across task state, reviews, CLI logs, and prior handoff notes.
     action: Compress the current truth into handoff/pr-brief.md, handoff/resume-index.md, and handoff/release-note.md before any ship action continues.
   - name: local-handoff-refresh
     when: Remote push or PR tooling is unavailable but the requirement is otherwise ready to land.

--- a/.claude/skills/cc-act/assets/PR_BRIEF_TEMPLATE.md
+++ b/.claude/skills/cc-act/assets/PR_BRIEF_TEMPLATE.md
@@ -171,7 +171,7 @@
 ## Consolidated Memory
 
 - `handoff path`: 
-- latest checkpoint / review summary:
+- latest task-state / review summary:
 - handoff entry for the next maintainer:
 
 ## Minimum Landing Pack

--- a/.claude/skills/cc-act/references/closure-contract.md
+++ b/.claude/skills/cc-act/references/closure-contract.md
@@ -54,7 +54,7 @@ detached HEAD 是分支事实，不是第 5 种 ship 模式。若远端可用且
 - `handoff/resume-index.md`（需要 handoff 时）
 - `handoff/release-note.md`（需要发布时）
 
-如果下一位接手者还得去翻零散 checkpoint 才知道从哪接，说明 act 还没收口。
+如果下一位接手者还得去翻零散过程笔记才知道从哪接，说明 act 还没收口。
 
 ## After Closing
 

--- a/.claude/skills/cc-act/references/git-commit-guidelines.md
+++ b/.claude/skills/cc-act/references/git-commit-guidelines.md
@@ -306,7 +306,7 @@ Commit 2:
 2. 已有打开 PR / MR 时，更新现有 PR / MR，不重复创建第二个。
 3. rebase 之后如果必须强推，只允许 `git push --force-with-lease`，不要裸 `--force`。
 4. 不改写公共分支历史。
-5. 不把 WIP、checkpoint、debug probe、临时日志留在最终历史里；必要时 squash/fixup 到语义 commit。
+5. 不把 WIP、AI 过程笔记、debug probe、临时日志留在最终历史里；必要时 squash/fixup 到语义 commit。
 6. 使用 `fixup!` / `squash!` 时，最终 ship 前要 autosquash 成干净历史，除非团队明确接受。
 
 ## Footer Trailers

--- a/.claude/skills/cc-check/SKILL.md
+++ b/.claude/skills/cc-check/SKILL.md
@@ -297,7 +297,7 @@ NO PASS WITHOUT FRESH EVIDENCE
 每条 failure ownership 还必须命名：
 
 - `errorName`：可搜索的错误名，例如 `MissingSpecReviewProof`
-- `artifactRefs`：指向 report、manifest、checkpoint、日志或命令输出
+- `artifactRefs`：指向 report、manifest、task state、日志或命令输出
 - `rescueAction`：下一步救援动作，不写空泛“检查一下”
 - `owner`：`branch` / `baseline` / `environment` / `external` / `unknown`
 

--- a/.claude/skills/cc-do/CHANGELOG.md
+++ b/.claude/skills/cc-do/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CC-Do Skill Changelog
 
+## v1.6.7 - 2026-05-13
+
+- stop generating per-task `context.md` and `checkpoint.json` during execution; `build-task-context.sh` now prints stdout only
+- make task recovery read code, Git state, `planning/tasks.md`, `task-manifest.json`, review verdicts, and CLI logs instead of AI-written process files
+- keep `events.jsonl` as an optional CLI log for debug or failure paths, not a default narrative artifact
+
 ## v1.6.6 - 2026-05-12
 
 - make `cc-devflow query workflow-context` the first execution context reset so `cc-do` reads compact task truth before opening full planning artifacts

--- a/.claude/skills/cc-do/PLAYBOOK.md
+++ b/.claude/skills/cc-do/PLAYBOOK.md
@@ -5,7 +5,7 @@
 `cc-plan | cc-investigate -> cc-do -> cc-check`
 
 - Enter from: an approved `planning/design.md` or `planning/analysis.md` with frozen tasks.
-- Stay in: `cc-do` while there are ready tasks, valid checkpoints, and the design contract still holds.
+- Stay in: `cc-do` while there are ready tasks, current task state is clear, and the design contract still holds.
 - Exit to: `cc-check` once the current task set has red/green/review evidence and no hidden execution gaps remain.
 - Reroute to: `cc-investigate` if repeated failures prove the root-cause contract is wrong, or `cc-plan` if the requirement design itself is wrong.
 
@@ -14,7 +14,7 @@
 开始前先把当前执行局面归到 4 类之一：
 
 - `implement`: 已有 ready task，可直接进入 TDD
-- `resume`: task 已有 runtime / checkpoint，需要续做
+- `resume`: task 状态或 Git 工作区显示中断，需要续做
 - `repair-from-investigation`: `planning/analysis.md` 已冻结，可直接修
 - `reroute-cc-investigate`: bug 根因未明，回调查入口
 - `review-fix`: scope 不变，只修 review 指向的问题
@@ -25,13 +25,13 @@
 
 1. 读取 `task-manifest.json`，先用 `scripts/select-ready-tasks.sh` 找出当前 ready tasks 和当前 wave。
 2. 如果有多于一个 ready task，要先跑 `scripts/detect-file-conflicts.sh`；有共享触点、父子路径触点或依赖关系就退回串行。
-3. 对每个要执行的 task，先用 `scripts/build-task-context.sh` 从 `planning/design.md`、`planning/tasks.md`、`planning/task-manifest.json` 组装上下文，再开始编码。
+3. 对每个要执行的 task，先用 `workflow-context` 和完整 task block 组装上下文；只有恢复卡住时才运行 `scripts/build-task-context.sh`，且它只输出 stdout。
 4. 如果当前任务来自 `cc-investigate`，把 `planning/analysis.md` 当成上游合同，不准一边做一边重开调查。
 5. 进入 TDD 闭环：先红，再绿，再重构。
-6. 每个关键节点都写 runtime：失败测试、Green 通过、Refactor、Review 结论、阻塞原因。
+6. 每个关键节点都留下客观证据：代码 diff、Git 状态、验证命令输出、review verdict；失败或 debug 才写 CLI event。
 7. 任务实现后，先过 `spec review`，再过 `code review`，review 不通过就回到实现。
 8. 两道 review 门都通过后，才能把任务标成完成，并把结果留给 `cc-check`。
-9. quick lane 只允许减少叙事，不允许减少 current task、checkpoint、verification、handoff 和 review gates。
+9. quick lane 只允许减少叙事，不允许减少 current task、verification、handoff 和 review gates。
 
 ## Local Kit
 
@@ -40,7 +40,7 @@
 - 需要判断当前任务时用 `scripts/check-task-status.sh`
 - 需要找 ready task 时用 `scripts/select-ready-tasks.sh`
 - 需要组装任务上下文时用 `scripts/build-task-context.sh`
-- 需要写 checkpoint 时用 `scripts/write-task-checkpoint.sh`
+- 不要写 checkpoint；`scripts/write-task-checkpoint.sh` 只是旧兼容入口，默认不生成 checkpoint 文件
 - 需要写 review 门结果时用 `scripts/record-review-decision.sh`
 - 需要校验任务闭环时用 `scripts/verify-task-gates.sh`
 - 需要勾选任务时用 `scripts/mark-task-complete.sh`
@@ -68,7 +68,7 @@
 - 纯配置变更
 - 上游明确禁止写测试的探索步骤
 
-每个例外都要写入 checkpoint：
+每个例外都要写入当前 task block 或 manifest task context：
 
 - `tddException.reason`
 - `tddException.risk`

--- a/.claude/skills/cc-do/SKILL.md
+++ b/.claude/skills/cc-do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-do
-version: 1.6.6
+version: 1.6.7
 description: Use when implementing planned tasks, resuming interrupted work, applying a frozen investigation handoff, or landing review feedback after cc-plan or cc-investigate.
 triggers:
   - 开始做 T003
@@ -17,9 +17,6 @@ reads:
   - references/parallel-dispatch.md
   - docs/guides/project-postmortem.md
 writes:
-  - path: devflow/changes/<change-key>/execution/tasks/<task-id>/checkpoint.json
-    durability: durable
-    required: true
   - path: devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl
     durability: durable
     required: false
@@ -35,21 +32,20 @@ writes:
 effects:
   - code changes
   - test changes
-  - workspace scratch runtime updates
+  - task status updates in planning/tasks.md and planning/task-manifest.json
 entry_gate:
   - Run `cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --data-only --no-trace --compact` first and follow its context-index `packetOnly`, `mustNotForget`, `sourceHashes`, `defaultOpen`, `currentTask`, `commandsToTrust`, and `openWhen.conditions` fields before opening deep artifacts.
-  - Read planning/design.md or planning/analysis.md, then planning/tasks.md, planning/task-manifest.json, change-meta.json, related capability specs, and the latest checkpoint only when the workflow context says the deep section is needed.
+  - Read planning/design.md or planning/analysis.md, then planning/tasks.md, planning/task-manifest.json, change-meta.json, related capability specs, current Git state, and CLI logs only when the workflow context says the deep section is needed.
   - Select only ready tasks whose dependencies, wave, touched paths, and file ownership are clear.
   - Reject parallel execution when touched paths overlap by exact path or parent/child path; submodule touches must be isolated unless the task explicitly owns that submodule.
   - If the current task cannot be restated from canonical artifacts, run a context reset before coding.
-  - Before each single-task execution, run a quick Project Postmortem search against `devflow/postmortems` using the task's touched files, capability, failure class, and model-risk terms; record applicable reminders or `no-project-postmortems-yet` in the checkpoint/events.
+  - Before each single-task execution, run a quick Project Postmortem search against `devflow/postmortems` using the task's touched files, capability, failure class, and model-risk terms; apply applicable reminders to the code path and mention only blocking/failure facts in CLI events.
   - "Validate the current task's TDD shape before coding: spec-style test name, one logical behavior, public verification path, allowed boundary mocks, Green minimality guard, and refactor candidates."
 exit_criteria:
-  - The current task has red/green evidence, public-seam test quality evidence, review evidence, and a resumable checkpoint trail.
+  - The current task has red/green evidence, public-seam test quality evidence, review evidence, and synchronized task status.
   - Red evidence proves one observable behavior through a public verification path; Green evidence shows only the minimal production change; Refactor evidence names the concrete smell removed or says why none was needed.
   - The completed task was closed through `scripts/mark-task-complete.sh`; manual checkbox/status edits are not valid completion evidence.
-  - Execution leaves the next verifier enough runtime truth to judge the task without chat memory.
-  - The task checkpoint or event log records the postmortem recall result for this task, including relevant principle/incident links or an explicit no-match verdict.
+  - Execution leaves the next verifier enough code, Git, task-status, verification-command, and CLI-log truth to judge the task without chat memory.
   - The honest next step is cc-check or an explicit reroute.
 reroutes:
   - when: Three failed repair attempts or new evidence show the investigation contract is wrong.
@@ -59,12 +55,12 @@ reroutes:
   - when: Implementation and reviews are complete for the current task set.
     target: cc-check
 recovery_modes:
-  - name: resume-from-checkpoint
+  - name: resume-from-task-state
     when: Work was interrupted but the current design contract is still valid.
-    action: Reload the latest checkpoint, rebuild task context, and continue from the last confirmed red/green/review milestone.
+    action: Reload workflow-context, planning/tasks.md, task-manifest.json, current Git state, and CLI logs; continue from the first pending or failed task.
   - name: context-reset
     when: The conversation history is noisy, stale, or cannot reproduce the exact task state.
-    action: Discard chat memory, reread planning/design.md or planning/analysis.md plus planning/tasks.md/planning/task-manifest.json and the latest checkpoint, then restate the next action before coding.
+    action: Discard chat memory, reread planning/design.md or planning/analysis.md plus planning/tasks.md/planning/task-manifest.json, current Git state, and CLI logs, then restate the next action before coding.
 tool_budget:
   read_files: 9
   search_steps: 6
@@ -87,7 +83,7 @@ tool_budget:
 
 写入任何 durable Markdown 或 JSON metadata 前，先运行 `cc-devflow config resolve --format policy`。
 
-- `Output language` 是机器约束，checkpoint、events、team-state 中新增的人类可读摘要必须记录并遵守它。
+- `Output language` 是机器约束；如果失败或 debug CLI 日志需要人类可读摘要，必须记录并遵守它。
 - `agent_preferences` 是用户偏好建议，只影响表达方式和结构选择，不覆盖本 Skill 的工作流边界。
 - 如果配置解析失败，先修配置或向用户说明阻塞，不要用默认语言继续生成正式文档。
 
@@ -125,13 +121,13 @@ tool_budget:
 | bug 还没搞清根因 | reroute 到 `cc-investigate` |
 | 收到 review comment，要在既定范围内修正 | `review-fix` |
 
-如果连“当前 task 是什么”都说不清，先别写代码，先跑 `cc-devflow query workflow-context`。只有它的 `openWhen` 指向 scheduling 或 recovery 时，才继续跑 `scripts/select-ready-tasks.sh` 和 `scripts/build-task-context.sh`。
+如果连“当前 task 是什么”都说不清，先别写代码，先跑 `cc-devflow query workflow-context`。只有它的 `openWhen` 指向 scheduling 或 recovery 时，才继续跑 `scripts/select-ready-tasks.sh`；`scripts/build-task-context.sh` 只能输出 stdout，不得生成 `context.md`。
 
 ## Harness Contract
 
-- Allowed actions: implement ready tasks, debug inside frozen scope, write runtime evidence, and apply review feedback that does not reopen design.
+- Allowed actions: implement ready tasks, debug inside frozen scope, update task status through the completion script, and apply review feedback that does not reopen design.
 - Forbidden actions: re-planning the requirement in place, blindly rerunning the whole requirement, or delegating tasks without full task context.
-- Required evidence: every task must leave red/green/review checkpoints plus objective failure notes when blocked.
+- Required evidence: every task must leave objective code/Git/test evidence; blocked or failed work may leave compact CLI events, but must not create AI-written process files.
 - Reroute rule: after repeated failed repairs or root-cause drift, stop patching and go back to `cc-investigate`; if scope or design truth breaks, go back to `cc-plan`; after task closure, hand off to `cc-check`.
 
 ## TDD Iron Law
@@ -145,13 +141,13 @@ NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
 1. Red：先写一个最小失败测试，运行并确认它因为目标行为缺失而失败。
 2. Green：只写让当前失败测试通过的最小生产代码。
 3. Refactor：只有 Green 之后才能清理命名、重复、结构和坏味道。
-4. Record：每一站都写入 `checkpoint.json`，必要时写入 `events.jsonl`。
+4. Record：任务状态只通过 `mark-task-complete.sh` 同步到 `planning/tasks.md` 与 `planning/task-manifest.json`；失败或 debug 时才写 `events.jsonl`。
 
 Red 不是形式上的红，而是公共 seam 上的行为缺失证明。测试必须通过公共接口、调用方流程、CLI/API/UI 路径或其它真实边界进入系统；只验证私有函数、内部调用次数、临时数据结构或 mock 自己控制的内部协作者，不算 TDD 证据。
 
 一个 Red 只证明一个逻辑行为。测试名要像规格说明，而不是实现步骤；结果要从同一类公共入口读回。直接查数据库、读内部状态、扫描临时文件或绕过 API 来证明行为，只在那个边界本身就是被测对象时成立。
 
-例外只能用于 throwaway prototype、纯生成文件、纯配置改动；例外必须写进 checkpoint 的 `tddException`，包含原因、风险和替代验证命令。测试第一次就绿，说明测试没有证明新行为，必须修测试而不是继续写生产代码。
+例外只能用于 throwaway prototype、纯生成文件、纯配置改动；例外必须写在当前 task block 或 manifest task context 中，包含原因、风险和替代验证命令。测试第一次就绿，说明测试没有证明新行为，必须修测试而不是继续写生产代码。
 
 禁止水平切片：不要先写一批测试，再写一批实现。每次只推进一个 tracer bullet：一个可观察行为的 Red -> 让它变绿的最小实现 -> 必要重构 -> 记录证据，然后再进入下一个行为。
 
@@ -169,9 +165,9 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 4. 只锁定当前 ready task，或一组经依赖、wave、精确触点与父子路径触点校验后可并行的 ready tasks。
 5. 如果这次来自 `cc-investigate`，必须把 `planning/analysis.md` 当成 canonical contract，而不是一边实现一边重新调查。
 6. 没有任务上下文，不准把任务扔给 subagent；先用 `workflow-context.currentTask`，不够时再用 `scripts/build-task-context.sh` 从 canonical artifacts 组装上下文。
-7. 如果 `task-manifest.json.metadata.lane == "quick"`，仍然必须有 current task、verification、checkpoint 和 handoff；quick 只缩短文档密度，不跳过证据。
+7. 如果 `task-manifest.json.metadata.lane == "quick"`，仍然必须有 current task、verification、task status 和唯一 next action；quick 只缩短文档密度，不跳过证据。
 8. 如果仓库含 `.gitmodules` 或 manifest 提供 `submodulePaths`，先用 `scripts/detect-file-conflicts.sh` 标出 `submoduleTouches`；只有触达该 submodule 的任务失去默认 worktree 隔离资格，未触达任务不能被无辜串行化。
-9. 每个单 task 开工前，用当前 task 的 touched files、capability、错误类型、模型风险词快速检索 `devflow/postmortems`；命中时把相关原则转成当前 task 的 guardrail，未命中也要在 checkpoint / events 里记录。
+9. 每个单 task 开工前，用当前 task 的 touched files、capability、错误类型、模型风险词快速检索 `devflow/postmortems`；命中时把相关原则转成当前 task 的 guardrail。不要为 no-match 生成过程文件。
 
 ## Loop
 
@@ -186,7 +182,7 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 9. 按 `Red -> Green -> Refactor` 推进，Green 只允许最小实现，不预铺未来测试尚未要求的分支、状态或 API。
 10. 如果当前 Red 需要新的 fixture 或 mock，先证明它仍从公共 seam 触发真实行为；fixture 缺字段、类型强转或内部 mock 都要写入 `tdd.testQuality.fixtureRisk` 或先修 seam。
 11. Refactor 后必须重跑相关测试，保持 Green；Red 状态下不重构。
-12. 每次推进都写 task runtime：`events.jsonl` + `checkpoint.json`，并记录 `postmortemRecall`、`tdd.testQuality`、`tdd.greenMinimality`、`tdd.refactorCandidates` 或 `tddException`。
+12. 每次推进都以代码 diff、Git 状态、验证命令输出和 task 状态为真相源；只有失败、阻塞或 debug 需要机器日志时才写 `events.jsonl`。
 13. 任务实现后，先过 `spec review`，再过 `code review`，两道门都过才算任务收口；这里只验证 spec delta，不回写长期 spec。
 14. 当前任务完成后，把可验证证据留给 `cc-check`。
 
@@ -194,8 +190,8 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 
 - 代码变更
 - 测试变更
-- `devflow/changes/<change-key>/execution/tasks/<task-id>/checkpoint.json`
-- `devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl`（仅 debug / failed 默认保留）
+- `planning/tasks.md` 与 `planning/task-manifest.json` 的 task 状态
+- `devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl`（仅 debug / failed 默认保留；CLI 自动日志，不写叙事 Markdown）
 - `planning/task-manifest.json` 里的 task review verdict
 
 ## Good Output
@@ -207,8 +203,8 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 - Green 证据说明 minimality guard：本轮只满足当前红灯，没有提前实现未来分支
 - Refactor 证据说明清掉了哪个具体坏味道，或者为什么当前 slice 不需要 refactor
 - 测试 fixture 说明真实 contract 字段和测试填充字段，没有用类型欺骗或内部 mock 制造假绿
-- runtime / checkpoint 足够让下一位接手者无损恢复
-- quick lane 也有 mini manifest、checkpoint、verification 和唯一 next action，不靠聊天记录继续
+- task status、Git diff、验证命令和必要 CLI 日志足够让下一位接手者恢复
+- quick lane 也有 mini manifest、verification 和唯一 next action，不靠聊天记录继续
 - reviewer 能顺着 review 记录和验证命令复盘这次实现
 
 ## Bundled Resources
@@ -219,8 +215,8 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 - 恢复分析：`scripts/recover-workflow.sh`
 - 任务状态：`scripts/check-task-status.sh`
 - ready 任务选择：`scripts/select-ready-tasks.sh`
-- 任务上下文组装：`scripts/build-task-context.sh`
-- checkpoint 记录：`scripts/write-task-checkpoint.sh`
+- 任务上下文组装：`scripts/build-task-context.sh`（stdout only，不落盘）
+- 旧 checkpoint 兼容入口：`scripts/write-task-checkpoint.sh`（不写 checkpoint，只在失败 / debug 时写事件）
 - review 记录：`scripts/record-review-decision.sh`
 - 任务闭环校验：`scripts/verify-task-gates.sh`
 - 任务勾选：`scripts/mark-task-complete.sh`
@@ -244,7 +240,7 @@ Refactor 只能发生在 Green 之后。优先处理当前 slice 暴露出的重
 14. 给 subagent 的输入必须包含：当前进度、当前任务全文、依赖状态、必读文件、验收标准、可信命令。
 15. 三次失败修补后必须先质疑调查合同或设计合同，而不是继续堆补丁。
 16. 完成任务后必须调用 `scripts/mark-task-complete.sh` 同步 `planning/task-manifest.json` 和 `planning/tasks.md`；禁止手工改 checkbox、status、currentTaskId 来冒充完成。
-17. 如果 `mark-task-complete.sh` 失败，说明 checkpoint、review gate 或任务依赖还没闭合；先修证据，再重跑脚本，不准绕过。
+17. 如果 `mark-task-complete.sh` 失败，说明 review gate 或任务依赖还没闭合；先修证据，再重跑脚本，不准绕过。
 
 ## Task Status Protocol
 
@@ -263,13 +259,13 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
 ```
 
 4. 脚本会先跑任务 gate，再同步 manifest、checkbox、`currentTaskId` 和整体状态。不要手动改这些字段。
-5. 如果任务不能完成，写 checkpoint / event / blocker；不要把失败任务标成完成。
+5. 如果任务不能完成，只在失败 / debug 需要时写 CLI event；不要生成过程 Markdown，也不要把失败任务标成完成。
 
 ## Exit Criteria
 
 - 当前任务有 Red/Green 证据
 - 当前任务有 `spec review` / `code review` 两道门证据
-- 恢复点已更新到 `devflow/changes/<change-key>/execution/tasks/<task-id>/`
+- 恢复点可从 `planning/tasks.md`、`planning/task-manifest.json`、Git 状态和必要 CLI 日志判断
 - 阻塞原因已写清楚
 - 下一步应进入 `cc-check`，或明确退回 `cc-investigate` / `cc-plan`
 

--- a/.claude/skills/cc-do/references/execution-recovery.md
+++ b/.claude/skills/cc-do/references/execution-recovery.md
@@ -22,19 +22,24 @@
 2. 为什么停在这
 3. 下一步必须先做什么
 
-如果这三件事不能只靠规范产物和最新 checkpoint 回答，就先做 context reset，不准继续依赖聊天记忆。
+如果这三件事不能只靠规范产物、Git 状态和 CLI 日志回答，就先做 context reset，不准继续依赖聊天记忆。
 
 ## Runtime Layout
 
-运行态证据按任务落在：
+默认执行真相来自：
 
-- `devflow/changes/<change-key>/execution/tasks/<task-id>/checkpoint.json`
-- `devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl`（仅 debug / failed 默认保留）
+- 代码和测试 diff
+- Git 状态
+- `planning/tasks.md` 的 checkbox
+- `planning/task-manifest.json` 的 task status / reviews / currentTaskId
+- `devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl`（仅 debug / failed 默认保留；CLI 自动日志）
 - `planning/task-manifest.json` 里的 `tasks[*].reviews`
 
-## Required Event Spine
+不得生成 `context.md`、`checkpoint.json`、review markdown 或其它 AI 手写过程文件。需要复盘时重新读取代码、Git、task 状态和 CLI 自动日志。
 
-一个健康任务最少要看见这些事件：
+## Optional Event Spine
+
+`events.jsonl` 只在 debug 或 failed 时存在。存在时可以包含这些事件：
 
 1. `context_ready`
 2. `red_failed`
@@ -48,11 +53,11 @@
 10. `spec_review_pass`
 11. `code_review_pass`
 
-如果 `events.jsonl` 没开启，至少仍要有最新 `checkpoint.json` 和 manifest review verdict。
+如果 `events.jsonl` 没开启，使用 manifest task status、`tasks.md` checkbox、review verdict 和验证命令输出恢复。
 
-## Checkpoint TDD Fields
+## Task Evidence Fields
 
-最新 checkpoint 至少能回答：
+当前 task block / manifest task / 验证输出至少能回答：
 
 - `red.command`
 - `red.exitStatus`
@@ -80,7 +85,7 @@
 - `review.spec.status`
 - `review.code.status`
 
-如果跳过 TDD，必须有 `tddException`，并写清替代验证。没有这些字段时，恢复执行先补证据，不准直接继续实现。
+如果跳过 TDD，必须有 `tddException` 或 task-level exception 说明，并写清替代验证。没有这些字段时，恢复执行先补证据，不准直接继续实现。
 
 ## Bug Rule
 
@@ -92,7 +97,7 @@
 ## Local Recovery Ladder
 
 1. 先重试当前命令或当前 task，而不是重跑整条 requirement
-2. 两次失败后回看证据链和 task context
+2. 两次失败后回看证据链、task block、Git diff 和 CLI 日志
 3. 三次失败后默认怀疑上游合同：根因漂移回 `cc-investigate`，范围 / 设计漂移回 `cc-plan`
 
 ## Subagent Rule
@@ -100,10 +105,10 @@
 给 subagent 的上下文至少包含：
 
 - 当前任务全文
-- 当前进度与最近 checkpoint
+- 当前进度与 manifest task status
 - 已满足 / 未满足的依赖
 - 必读文件
 - 验收标准
 - 验证命令
 - 不做项 / 边界
-- quick lane 是否仍有 mini manifest、checkpoint、verification 和唯一 next action
+- quick lane 是否仍有 mini manifest、verification 和唯一 next action

--- a/.claude/skills/cc-do/scripts/build-task-context.sh
+++ b/.claude/skills/cc-do/scripts/build-task-context.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # ------------------------------------------------------------
-# 组装当前任务的执行上下文，并记录 context_ready 事件
+# 组装当前任务的执行上下文，只输出到 stdout
 # ------------------------------------------------------------
 
 usage() {
@@ -51,11 +51,7 @@ if [[ -z "$task_json" ]]; then
 fi
 
 change_id="$(jq -r '.changeId // .requirementId // "REQ-UNKNOWN"' "$manifest")"
-runtime_task_dir="$(req_do_task_runtime_dir "$CHANGE_DIR" "$TASK_ID")"
-output_path="$runtime_task_dir/context.md"
 ready_json="$("$SCRIPT_DIR/select-ready-tasks.sh" --manifest "$manifest")"
-
-mkdir -p "$runtime_task_dir"
 
 list_or_none() {
   local value="$1"
@@ -168,21 +164,12 @@ sync_status="$(jq -r '.spec.syncStatus // "unknown"' "$spec_source" 2>/dev/null 
   echo
   echo "## Context Reset"
   echo
-  echo "- If chat context drifts, discard conversational memory and reload only the canonical files above plus the latest checkpoint."
-  echo "- Do not continue from memory if the current task, active phase, or latest checkpoint summary cannot be restated exactly."
+  echo "- If chat context drifts, discard conversational memory and reload only the canonical files above, current Git state, and CLI logs."
+  echo "- Do not continue from memory if the current task, active phase, or latest verification status cannot be restated exactly."
   echo
   if [[ -f "$resume_index" ]]; then
     echo "## Optional Resume Index"
     echo
     cat "$resume_index"
   fi
-} > "$output_path"
-
-"$SCRIPT_DIR/write-task-checkpoint.sh" \
-  --dir "$CHANGE_DIR" \
-  --task "$TASK_ID" \
-  --status pending \
-  --summary "Task context assembled" \
-  --next-action "Write the failing test for $TASK_ID" >/dev/null
-
-cat "$output_path"
+}

--- a/.claude/skills/cc-do/scripts/record-review-decision.sh
+++ b/.claude/skills/cc-do/scripts/record-review-decision.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # ------------------------------------------------------------
-# 记录 spec / code review 结论，并同步 runtime / manifest
+# 记录 spec / code review 结论，并同步 manifest；失败时保留 CLI 事件
 # ------------------------------------------------------------
 
 usage() {
@@ -46,11 +46,8 @@ fi
 CHANGE_DIR="$(req_do_resolve_change_dir "$REQ_DIR")"
 manifest="$(req_do_manifest_path "$CHANGE_DIR")"
 change_id="$(jq -r '.changeId // .requirementId // "REQ-UNKNOWN"' "$manifest" 2>/dev/null || basename "$CHANGE_DIR")"
-runtime_task_dir="$(req_do_task_runtime_dir "$CHANGE_DIR" "$TASK_ID")"
 timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 event_name="${GATE}_review_${VERDICT}"
-
-mkdir -p "$runtime_task_dir"
 
 if [[ -f "$manifest" ]]; then
   tmp_manifest="$(mktemp)"
@@ -66,7 +63,9 @@ if [[ -f "$manifest" ]]; then
   mv "$tmp_manifest" "$manifest"
 fi
 
-if [[ -f "$runtime_task_dir/events.jsonl" || "$VERDICT" != "pass" ]]; then
+if [[ "$VERDICT" != "pass" ]]; then
+  runtime_task_dir="$(req_do_task_runtime_dir "$CHANGE_DIR" "$TASK_ID")"
+  mkdir -p "$runtime_task_dir"
   jq -nc \
     --arg type "$event_name" \
     --arg changeId "$change_id" \

--- a/.claude/skills/cc-do/scripts/recover-workflow.sh
+++ b/.claude/skills/cc-do/scripts/recover-workflow.sh
@@ -68,17 +68,15 @@ if [[ -f "$report" ]]; then
   echo "- Latest check verdict: $verdict"
 fi
 
-if [[ -n "$change_id" ]]; then
-  runtime_dir="$(req_do_execution_dir "$CHANGE_DIR")/tasks"
+if [[ -f "$manifest" ]]; then
+  echo
+  echo "## Task Status"
+  jq -r '.tasks[]? | "- " + .id + ": " + (.status // "pending") + (if .lastError then " - " + .lastError else "" end)' "$manifest" 2>/dev/null || true
 fi
 
-if [[ -n "${runtime_dir:-}" && -d "$runtime_dir" ]]; then
-  echo "- Runtime dir: $runtime_dir"
-
-  while IFS= read -r checkpoint_path; do
-    task_id="$(jq -r '.taskId // "unknown"' "$checkpoint_path" 2>/dev/null || echo unknown)"
-    checkpoint_status="$(jq -r '.status // "unknown"' "$checkpoint_path" 2>/dev/null || echo unknown)"
-    checkpoint_summary="$(jq -r '.summary // ""' "$checkpoint_path" 2>/dev/null || echo "")"
-    echo "- Checkpoint $task_id: $checkpoint_status ${checkpoint_summary:+- $checkpoint_summary}"
-  done < <(find "$runtime_dir" -name checkpoint.json | sort)
+if git -C "$CHANGE_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
+  repo_root="$(git -C "$CHANGE_DIR" rev-parse --show-toplevel)"
+  echo
+  echo "## Git State"
+  git -C "$repo_root" status --short
 fi

--- a/.claude/skills/cc-do/scripts/verify-task-gates.sh
+++ b/.claude/skills/cc-do/scripts/verify-task-gates.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # ------------------------------------------------------------
-# 校验任务是否完成 Red / Green / Refactor / Review 闭环
+# 校验任务状态、依赖和可选 CLI 事件顺序
 # ------------------------------------------------------------
 
 usage() {
@@ -36,18 +36,20 @@ CHANGE_DIR="$(req_do_resolve_change_dir "$REQ_DIR")"
 manifest="$(req_do_manifest_path "$CHANGE_DIR")"
 runtime_task_dir="$(req_do_task_runtime_dir "$CHANGE_DIR" "$TASK_ID")"
 events_file="$runtime_task_dir/events.jsonl"
-checkpoint_file="$runtime_task_dir/checkpoint.json"
 
-if [[ ! -f "$checkpoint_file" ]]; then
-  echo "Missing $checkpoint_file" >&2
-  exit 1
-fi
-
-checkpoint_status="$(jq -r '.status // "unknown"' "$checkpoint_file" 2>/dev/null || echo unknown)"
-[[ "$checkpoint_status" == "passed" ]] || {
-  echo "Task $TASK_ID checkpoint status is not passed" >&2
+task_json="$(jq -c --arg task "$TASK_ID" '.tasks[] | select(.id == $task)' "$manifest" 2>/dev/null || true)"
+[[ -n "$task_json" ]] || {
+  echo "Task $TASK_ID not found in manifest" >&2
   exit 1
 }
+
+while IFS= read -r dependency; do
+  dep_status="$(jq -r --arg dep "$dependency" '.tasks[] | select(.id == $dep) | .status // "pending"' "$manifest" 2>/dev/null || echo pending)"
+  [[ "$dep_status" == "passed" || "$dep_status" == "completed" || "$dep_status" == "done" || "$dep_status" == "verified" ]] || {
+    echo "Task $TASK_ID dependency $dependency is not complete" >&2
+    exit 1
+  }
+done < <(jq -r '(.dependsOn // [])[]?' <<<"$task_json")
 
 spec_verdict="$(jq -r --arg task "$TASK_ID" '.tasks[] | select(.id == $task) | .reviews.spec // "pending"' "$manifest" 2>/dev/null || echo pending)"
 code_verdict="$(jq -r --arg task "$TASK_ID" '.tasks[] | select(.id == $task) | .reviews.code // "pending"' "$manifest" 2>/dev/null || echo pending)"

--- a/.claude/skills/cc-do/scripts/write-task-checkpoint.sh
+++ b/.claude/skills/cc-do/scripts/write-task-checkpoint.sh
@@ -3,13 +3,13 @@
 set -euo pipefail
 
 # ------------------------------------------------------------
-# 写入 task checkpoint.json / events.jsonl
+# 兼容旧入口：只写必要的 CLI 事件，不再生成 checkpoint.json
 # ------------------------------------------------------------
 
 usage() {
   cat <<'EOF'
 Usage:
-  write-task-checkpoint.sh --dir path/to/change --task T001 --status pending|running|passed|failed|skipped --summary "..." [--event context_ready] [--attempt 0] [--session session-id] [--next-action "..."] [--tdd-json '{"red":...}']
+  write-task-checkpoint.sh --dir path/to/change --task T001 --status pending|running|passed|failed|skipped [--summary "..."] [--event context_ready] [--attempt 0] [--session session-id] [--next-action "..."] [--tdd-json '{"red":...}']
 EOF
 }
 
@@ -41,7 +41,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$REQ_DIR" || -z "$TASK_ID" || -z "$STATUS" || -z "$SUMMARY" ]]; then
+if [[ -z "$REQ_DIR" || -z "$TASK_ID" || -z "$STATUS" ]]; then
   usage
   exit 1
 fi
@@ -49,11 +49,8 @@ fi
 CHANGE_DIR="$(req_do_resolve_change_dir "$REQ_DIR")"
 manifest="$(req_do_manifest_path "$CHANGE_DIR")"
 change_id="$(jq -r '.changeId // .requirementId // "REQ-UNKNOWN"' "$manifest" 2>/dev/null || basename "$REQ_DIR")"
-plan_version="$(jq -r '.metadata.planVersion // 1' "$manifest" 2>/dev/null || echo 1)"
 timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 runtime_task_dir="$(req_do_task_runtime_dir "$CHANGE_DIR" "$TASK_ID")"
-
-mkdir -p "$runtime_task_dir"
 
 if [[ -z "$SESSION_ID" ]]; then
   SESSION_ID="${TASK_ID}-$(date -u +%s)"
@@ -68,28 +65,8 @@ if [[ -n "$TDD_JSON" ]]; then
   fi
 fi
 
-jq -nc \
-  --arg changeId "$change_id" \
-  --arg taskId "$TASK_ID" \
-  --arg sessionId "$SESSION_ID" \
-  --arg planVersion "$plan_version" \
-  --arg status "$STATUS" \
-  --arg summary "$SUMMARY" \
-  --arg timestamp "$timestamp" \
-  --arg attempt "$ATTEMPT" \
-  --argjson tdd "$tdd_payload" \
-  '{
-    changeId: $changeId,
-    taskId: $taskId,
-    sessionId: $sessionId,
-    planVersion: ($planVersion | tonumber),
-    status: $status,
-    summary: $summary,
-    timestamp: $timestamp,
-    attempt: ($attempt | tonumber)
-  } + (if $tdd == null then {} else {tdd: $tdd} end)' > "$runtime_task_dir/checkpoint.json"
-
 if [[ -n "$EVENT_TYPE" || "$STATUS" == "failed" ]]; then
+  mkdir -p "$runtime_task_dir"
   jq -nc \
     --arg type "${EVENT_TYPE:-status_$STATUS}" \
     --arg changeId "$change_id" \
@@ -99,6 +76,7 @@ if [[ -n "$EVENT_TYPE" || "$STATUS" == "failed" ]]; then
     --arg summary "$SUMMARY" \
     --arg nextAction "$NEXT_ACTION" \
     --arg timestamp "$timestamp" \
+    --argjson tdd "$tdd_payload" \
     '{
       type: $type,
       changeId: $changeId,
@@ -108,7 +86,7 @@ if [[ -n "$EVENT_TYPE" || "$STATUS" == "failed" ]]; then
       summary: $summary,
       nextAction: $nextAction,
       timestamp: $timestamp
-    }' >> "$runtime_task_dir/events.jsonl"
+    } + (if $tdd == null then {} else {tdd: $tdd} end)' >> "$runtime_task_dir/events.jsonl"
 fi
 
-echo "Wrote $runtime_task_dir/checkpoint.json"
+echo "No checkpoint written; task truth lives in planning/tasks.md and planning/task-manifest.json"

--- a/.claude/skills/cc-investigate/assets/TASKS_TEMPLATE.md
+++ b/.claude/skills/cc-investigate/assets/TASKS_TEMPLATE.md
@@ -17,7 +17,7 @@
 - Runtime reset: run `cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --cwd <repo-root> --data-only --no-trace --compact` before `cc-do`, `cc-check`, or `cc-act`; use `packetOnly` plus `mustNotForget` first, verify `sourceHashes`, open `defaultOpen` refs only when needed, and reserve `deepOpen` for matching `openWhen.conditions`.
 - Open for root-cause doubt: `planning/tasks.md#Root Cause Contract` Project Postmortem Recall, Feedback Loop, Evidence Chain, Boundary Probe Matrix.
 - Open for scheduling: `planning/task-manifest.json`, dependencies, touched files.
-- Open for audit/recovery: checkpoint files, report-card findings, Workflow Forensics.
+- Open for audit/recovery: Git state, CLI logs, report-card findings, Workflow Forensics.
 
 ## Root Cause Contract
 
@@ -111,7 +111,7 @@ Risk / Escalate If:
   Read first: `analysis.md`, `path/to/test`
   Project postmortem search: `rg -n "<root cause|module|failure-class|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test -- path/to/test`
-  Evidence: passing output + checkpoint
+  Evidence: passing output + Git diff
   Do not re-decide: root cause, first bad state, original trigger, allowed files, forbidden files
   Ready when: T001 已证明同一个用户症状存在，analysis 已证明根因源头和 counterfactual proof
 

--- a/.claude/skills/cc-plan/CHANGELOG.md
+++ b/.claude/skills/cc-plan/CHANGELOG.md
@@ -5,6 +5,7 @@
 - collapse the default planning artifact surface to `planning/tasks.md` plus CLI-generated `task-manifest.json` and `change-meta.json`
 - move the human-authored design contract into `planning/tasks.md#Contract Summary` so `planning/design.md` is legacy fallback only
 - archive legacy design templates under `assets/legacy/` and keep new task handoffs rooted in `assets/TASKS_TEMPLATE.md`
+- ban generated execution process files from new task plans: no `context.md`, `checkpoint.json`, review markdown, or AI-written process notes under `execution/tasks`
 
 ## v3.8.7 - 2026-05-13
 

--- a/.claude/skills/cc-plan/PLAYBOOK.md
+++ b/.claude/skills/cc-plan/PLAYBOOK.md
@@ -132,7 +132,7 @@
 - 测试框架来源是什么，现有覆盖是 strong、happy-path-only、smoke-only 还是 missing？
 - task 是否以端到端 tracer bullet 为单位，而不是按层水平拆？
 - Green 任务的 minimality guard 是什么，如何防止提前实现未来测试还没要求的代码？
-- Refactor checkpoint 要处理哪些具体坏味道，哪些因为不在当前 Green 后可安全 defer？
+- Refactor gate 要处理哪些具体坏味道，哪些因为不在当前 Green 后可安全 defer？
 - 哪些生产失败模式已经处理，哪些 defer 到 backlog？
 - WHAT/WHY ambiguity score 是否低到足以拆任务？如果不够，blocked question 是什么？
 - source evidence 哪些是 internal contract、repo evidence、external evidence、untrusted text？外部文本有没有被误当成 instruction？

--- a/.claude/skills/cc-plan/SKILL.md
+++ b/.claude/skills/cc-plan/SKILL.md
@@ -41,7 +41,7 @@ entry_gate:
   - Freeze problem, constraints, non-goals, and success criteria before proposing implementation tasks.
   - If the raw ask spans multiple independent subsystems, split it back into roadmap stages or separate REQ/FIX candidates before asking implementation details.
   - "For non-trivial designs, compare named option roles: minimal viable, ideal architecture, and optional hybrid. Do not default to smallest unless it best serves the goal."
-  - Plan executable work as Red/Green/Refactor by default; identify the first failing test before any production implementation task, or write an explicit TDD exception with replacement evidence.
+  - Plan executable work as Red/Green/Refactor by default; identify the first failing test before any production implementation task, or write an explicit TDD exception with replacement evidence in the task contract.
   - Generate `planning/tasks.md` from `assets/TASKS_TEMPLATE.md` semantics, including every required task field, the execution protocol, and the exact task completion command; do not free-form a loose checklist.
   - "Make progressive disclosure executable: `planning/tasks.md` must name `cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --data-only --no-trace --compact` as the first context reset before `cc-do`, `cc-check`, or `cc-act` opens deep planning sections."
   - "Keep `planning/task-manifest.json` lean: it is the machine execution graph, not a mirror of the design narrative or task protocol prose."
@@ -62,7 +62,7 @@ exit_criteria:
   - "`cc-devflow query workflow-context` can derive the next skill, packet digests, default section refs, current task, trusted commands, and deep-open triggers from the frozen artifacts."
   - planning/tasks.md contains the task-template compliance section and script-based completion protocol, and every task block includes its completion command.
   - task-manifest.json omits retired narrative/protocol mirrors such as `executionProtocol`, `planningMeta.requirementBrief`, `planningMeta.ambiguityGate`, `planningMeta.reviewLoop`, and task-level `completion`; those details belong in `planning/tasks.md`.
-  - The task breakdown preserves test-first execution; failing-test tasks precede implementation tasks, refactor checkpoints are visible, and any TDD exception is justified.
+  - The task breakdown preserves test-first execution; failing-test tasks precede implementation tasks, refactor gates are visible, and any TDD exception is justified.
   - "Testability decisions make the public seam natural: small interface, deep implementation, injected boundary dependencies, returned results where practical, and boundary mocks only where the system genuinely leaves the repo."
   - AI Leverage Decision Lens is recorded in planning/tasks.md and task-manifest.json.planningMeta.aiLeverageDecisionLens before executable tasks are generated.
   - Project Postmortem Recall Gate is recorded in planning/tasks.md before executable tasks are generated; relevant lessons have concrete task impacts or explicit no-op reasons.
@@ -265,7 +265,7 @@ bash .claude/skills/cc-plan/scripts/next-change-key.sh --prefix REQ --descriptio
 2. 当前可做任务由 `planning/task-manifest.json.currentTaskId` 和 ready-task 脚本决定，不得凭聊天记忆挑任务。
 3. 每个 task 必须保留模板字段：Goal、TDD phase、Files、Read first、Verification、Evidence、test seam、mock boundary、green minimality 或 refactor candidates。
 4. 任务完成后必须调用 `mark-task-complete.sh` 同步 `planning/task-manifest.json` 和 `planning/tasks.md`；禁止手工把 checkbox 改成 `[x]`，禁止只改 manifest，禁止完成后不标记。
-5. 如果完成脚本失败，不能手改绕过；先修复缺失 gate、checkpoint 或 review evidence，再重跑脚本。
+5. 如果完成脚本失败，不能手改绕过；先修复缺失 gate、review evidence 或依赖状态，再重跑脚本。
 
 生成 `planning/task-manifest.json` 时必须保持瘦身边界：
 
@@ -539,7 +539,7 @@ STOP: wait for the user answer before continuing.
 3. 每个可观察行为变更默认拆成 `Red -> Green -> Refactor`：
    - Red：先写 `[TEST]` 任务，目标是用最小失败测试证明目标行为缺失。
    - Green：再写 `[IMPL]` 任务，只做让对应红灯转绿的最小生产实现，不预先铺未来测试还没要求的 API、状态或分支。
-   - Refactor：最后写 `[REFACTOR]` 或在实现任务中明确 refactor checkpoint，说明何时清理重复、长方法、浅模块、feature envy、primitive obsession、命名和三层以上分支。
+   - Refactor：最后写 `[REFACTOR]` 或在实现任务中明确 refactor gate，说明何时清理重复、长方法、浅模块、feature envy、primitive obsession、命名和三层以上分支。
 4. 禁止水平切片：不能先写一批测试、再写一批实现。计划必须按 tracer bullet 垂直切片排列：一个行为红灯 -> 最小实现转绿 -> 必要重构，然后再进入下一个行为。
 5. `planning/tasks.md` 不能把测试和实现塞进同一个 task。一个 task 同时写“实现并测试”就是计划失败。
 6. `planning/tasks.md` 的每个 `[TEST]` task 必须写清 test name、one logical behavior、test seam、public verification path、behavior asserted、allowed mocks、feedback loop type、implementation-detail risk。

--- a/.claude/skills/cc-plan/assets/TASKS_TEMPLATE.md
+++ b/.claude/skills/cc-plan/assets/TASKS_TEMPLATE.md
@@ -17,7 +17,7 @@
 - Default read: Plan Meta, Contract Summary, Execution Handoff, Execution Protocol, current task block.
 - Open for scheduling: `planning/task-manifest.json`, ready-task selector output, dependencies, touched files.
 - Open for parallel or ownership questions: Implementation Surface Map, Tracer Bullet Map.
-- Open for audit/recovery: Task Quality Bar, checkpoint files, review/report-card.json.
+- Open for audit/recovery: Task Quality Bar, Git state, CLI logs, review/report-card.json.
 
 ## Contract Summary
 
@@ -105,8 +105,9 @@ ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合�
 - Task block rule: read the full task block before coding; title-only execution is invalid.
 - Contract sync rule: every task must inherit one row from Task Contract Matrix; if the matrix lacks source funnel rounds, interface/data contract, do-not-re-decide items, or artifact updates, return to `planning/tasks.md#Contract Summary` before coding.
 - Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
-- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
-- Postmortem recall rule: before each task, search `devflow/postmortems` with the task's touched files, capability, failure class, and model-risk terms; record relevant reminders or an explicit no-match in checkpoint/events.
+- Completion failure: if the script fails, fix the missing review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+- Postmortem recall rule: before each task, search `devflow/postmortems` with the task's touched files, capability, failure class, and model-risk terms; apply relevant reminders to the work. Do not generate no-match process files.
+- Runtime file ban: do not generate `execution/tasks/<task-id>/context.md`, `checkpoint.json`, review markdown, or any AI-written process file. Recovery reads code, Git, `planning/tasks.md`, `planning/task-manifest.json`, and CLI logs only.
 
 ```bash
 cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --cwd <repo-root> --data-only --no-trace --compact
@@ -156,7 +157,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
   Project postmortem search: `rg -n "<test seam|capability|module|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test -- path/to/test`
   Evidence: failing output
-  Completion: after failing evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T001`; do not hand-edit status.
+  Completion: after failing evidence and required review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T001`; do not hand-edit status.
   Coverage: unit / integration / e2e / eval; regression: yes / no
   Spec-style test name: 测试名像规格说明，描述可观察行为
   One logical behavior: yes / no
@@ -179,8 +180,8 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
   Read first: `design.md`, `path/to/test`
   Project postmortem search: `rg -n "<implementation surface|module|failure-class|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test -- path/to/test`
-  Evidence: passing output + checkpoint
-  Completion: after green evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T002`; do not hand-edit status.
+  Evidence: passing output + Git diff
+  Completion: after green evidence and required review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T002`; do not hand-edit status.
   Green minimality guard: 只写当前红灯要求的最小实现，不预铺未来行为、分支或 API
   Vertical slice: Slice 1
   Ready when: T001 已经见红，且当前 touched files 不和其他并行任务冲突
@@ -199,7 +200,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
   Project postmortem search: `rg -n "<test seam|capability|module|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test -- path/to/other.test`
   Evidence: failing output
-  Completion: after failing evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T003`; do not hand-edit status.
+  Completion: after failing evidence and required review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T003`; do not hand-edit status.
   Coverage: unit / integration / e2e / eval; regression: yes / no
   Spec-style test name: 测试名像规格说明，描述可观察行为
   One logical behavior: yes / no
@@ -223,7 +224,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
   Project postmortem search: `rg -n "<implementation surface|module|failure-class|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test -- path/to/other.test`
   Evidence: passing output + review notes
-  Completion: after green evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T004`; do not hand-edit status.
+  Completion: after green evidence and required review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T004`; do not hand-edit status.
   Green minimality guard: 只写当前红灯要求的最小实现，不预铺未来行为、分支或 API
   Vertical slice: Slice 2
   Ready when: T003 已经见红，且文件触点与其他 `[P]` 任务不冲突
@@ -242,7 +243,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
   Project postmortem search: `rg -n "<refactor candidate|code smell|module|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test -- path/to/test path/to/other.test`
   Evidence: refactor diff + repeated green output
-  Completion: after refactor evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T005`; do not hand-edit status.
+  Completion: after refactor evidence and required review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T005`; do not hand-edit status.
   Refactor candidates: duplication / long method / shallow module / feature envy / primitive obsession / naming / >3 nesting / newly exposed old code smell
   Ready when: 对应 Red/Green 任务都已完成，且清理不会扩大 scope
 
@@ -251,14 +252,14 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key
   Source funnel rounds: Execution Architecture; Task Contract; Final Approval.
   Contract: user story `all planned stories`; file responsibility `verification evidence`; method/interface `all changed public seams`; key fields `all contract fields`; input/output `not applicable`; failure path `gate failure blocks completion`; AFK/HITL `AFK`.
   Do not re-decide: scope, test framework, gate set, completion protocol.
-  Artifact updates: review evidence / checkpoint only; no behavior changes.
+  Artifact updates: review evidence only; no behavior changes and no execution process files.
   TDD phase: evidence
   Files: `command or file`
   Read first: `tasks.md`, `task-manifest.json`
   Project postmortem search: `rg -n "<verification|release|tooling|model-risk>" devflow/postmortems` or record `no-project-postmortems-yet`
   Verification: `npm test && npm run lint`
   Evidence: gate output
-  Completion: after gate evidence and required checkpoint/review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T006`; do not hand-edit status.
+  Completion: after gate evidence and required review records exist, run `bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest devflow/changes/<change-key>/planning/task-manifest.json --tasks devflow/changes/<change-key>/planning/tasks.md --task T006`; do not hand-edit status.
   Ready when: 当前 requirement 的实现任务都已收口
 
 > `[P]` 只表示“依赖满足后有资格并行”，不表示可以无脑同时开发。

--- a/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
+++ b/.claude/skills/cc-plan/assets/TASK_MANIFEST_TEMPLATE.json
@@ -142,7 +142,8 @@
         ],
         "notes": [
           "Write the failing test first",
-          "Do not change unrelated contracts in this task"
+          "Do not change unrelated contracts in this task",
+          "Do not generate execution context.md, checkpoint.json, review markdown, or AI-written process files"
         ]
       },
       "reviews": {

--- a/.claude/skills/cc-plan/assets/legacy/TINY_DESIGN_TEMPLATE.md
+++ b/.claude/skills/cc-plan/assets/legacy/TINY_DESIGN_TEMPLATE.md
@@ -194,7 +194,7 @@
 - Tracer bullet order:
 - Green implementation check:
 - Green minimality guard:
-- Refactor checkpoint:
+- Refactor gate:
 - Refactor candidates:
 - TDD exceptions:
 - Regression test required:

--- a/.claude/skills/cc-plan/references/planning-contract.md
+++ b/.claude/skills/cc-plan/references/planning-contract.md
@@ -88,7 +88,7 @@
 - Completion command：调用 `mark-task-complete.sh`，同步 `planning/task-manifest.json` 与 `planning/tasks.md`
 - Forbidden shortcuts：禁止手工改 checkbox、manifest status 或 `currentTaskId`
 
-行为变更任务必须先有 `[TEST]` 红灯任务，再有 `[IMPL]` 绿灯任务，最后有 `[REFACTOR]` 或明确 refactor checkpoint。纯文档、纯配置、纯生成文件、throwaway prototype 可以例外，但必须写明原因、风险和替代验证。
+行为变更任务必须先有 `[TEST]` 红灯任务，再有 `[IMPL]` 绿灯任务，最后有 `[REFACTOR]` 或明确 refactor gate。纯文档、纯配置、纯生成文件、throwaway prototype 可以例外，但必须写明原因、风险和替代验证。
 不要把计划拆成水平层：一批测试、一批服务、一批 UI。每个切片完成后都应该能证明一个真实行为。
 也不要把一批 Red 一次性写完再批量实现。每条 tracer bullet 只证明一个可观察行为，Green 只做当前红灯要求的最小实现；下一条 Red 可以吸收上一轮学到的事实，但不能越过冻结边界。
 
@@ -99,7 +99,8 @@
 - task 选择来自 `currentTaskId` 或 `select-ready-tasks.sh`
 - 每个 task 必须按模板字段完整展开，不能退化成标题清单
 - 完成 task 必须调用 `mark-task-complete.sh`
-- 脚本失败时修 evidence / checkpoint / review gate 后重跑，禁止手工绕过
+- 脚本失败时修 evidence / review gate / dependency state 后重跑，禁止手工绕过
+- 禁止规划或要求生成执行过程文件：`execution/tasks/<task-id>/context.md`、`checkpoint.json`、review markdown 或其它 AI 手写过程文件都不是默认真相源；恢复只看代码、Git、`planning/tasks.md`、`task-manifest.json` 和 CLI 自动日志。
 - completion command、required-before-completion 和 forbidden-shortcuts 写在 `planning/tasks.md` 的 task block；不得再写入 `task-manifest.json.executionProtocol` 或 `tasks[].completion`
 - `task-manifest.json` 不写顶层 `status`、`activePhase`、`sourceRoadmap` 或 `spec`；整体完成度从 `tasks[].status` 派生，phase 从任务图派生，roadmap/spec 状态从 `change-meta.json` 和 `devflow/roadmap.json` 读取。
 

--- a/.claude/skills/cc-review/SKILL.md
+++ b/.claude/skills/cc-review/SKILL.md
@@ -48,7 +48,7 @@ entry_gate:
   - For broad implementation or mixed reviews, decide whether the risk-lane review swarm profile is required; record used, skipped, or unavailable lanes in `review-ledger.jsonl`.
   - Freeze the requested scope before finding smells; only report smells inside the requirement blast radius or clearly amplified by the current work.
 exit_criteria:
-  - review-ledger.jsonl records selected tools, review nodes, skipped nodes with reasons, checkpoint order, and final route through CLI events.
+  - review-ledger.jsonl records selected tools, review nodes, skipped nodes with reasons, review order, and final route through CLI events.
   - review-ledger.jsonl appends one record per reviewed node with status, evidence refs, findings, and follow-up route.
   - review-agent-results.jsonl records read-only reviewer outputs when subagents are used, or the review ledger records why agents were unavailable or unnecessary.
   - review-findings.json exists only when later agents need structured findings; human Markdown is rendered on demand with `cc-devflow review render`.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ flowchart TD
 | `cc-dev` | A selected objective should be driven in the current worktree to a remote PR | PDCA/IDCA artifacts plus a PR or handoff |
 | `cc-plan` | A feature or change needs scope, design, and task freezing | `planning/tasks.md#Contract Summary`, `task-manifest.json`, `change-meta.json` |
 | `cc-investigate` | A bug needs symptom, reproduction, root cause, and repair boundary | `planning/tasks.md#Root Cause Contract`, `task-manifest.json`, `change-meta.json` |
-| `cc-do` | Planned or investigated work needs implementation | code, tests, checkpoints, scratch runtime |
+| `cc-do` | Planned or investigated work needs implementation | code, tests, task state, scratch runtime |
 | `cc-review` | Complex plans, investigations, or diffs need optional deep multi-round review before implementation or verification | `review-ledger.jsonl`, optional `review-findings.json`, optional rendered Markdown |
 | `cc-pr-review` | A remote PR needs an independent review session before landing | PR review packet, findings, and landing verdict |
 | `cc-pr-land` | Reviewed PRs need rebase-first landing into main with parity proof | integrated main plus local/remote parity evidence |
@@ -244,7 +244,7 @@ The currently distributed skill folders are:
 
 - `devflow/specs/` stores durable capability truth: `INDEX.md` plus `capabilities/*.md`.
 - New change directories use `REQ-<number>-<description>` for requirements or `FIX-<number>-<description>` for bug fixes. `REQ` and `FIX` numbers advance independently, so the same number may exist in both prefixes. Parallel worktrees may also create repeated numbers; the full change key must use a specific description to distinguish the work.
-- `devflow/changes/<change>/` stores durable change truth: `change-meta.json`, `planning/tasks.md`, CLI-generated `task-manifest.json`, review ledger/findings records, task `checkpoint.json`, `report-card.json`, and one final handoff file.
+- `devflow/changes/<change>/` stores durable change truth: `change-meta.json`, `planning/tasks.md`, CLI-generated `task-manifest.json`, review ledger/findings records, optional CLI logs for debug/failure, `report-card.json`, and one final handoff file. Task `context.md`, `checkpoint.json`, review markdown, and AI-written process files are not default durable truth.
 - New changes default to one human-authored Markdown artifact: `planning/tasks.md`. Feature plans put the frozen design in `## Contract Summary`; bug investigations put root-cause truth in `## Root Cause Contract`. Legacy `planning/design.md`, `planning/analysis.md`, and `cc-review-*.md` remain fallback inputs, not new default writes.
 - Use `cc-devflow task-contract validate`, `npm run verify:artifacts`, and `npm run benchmark:artifacts` to keep workflow artifacts small and measurable.
 - `devflow/workspaces/<change>/` stores ephemeral runtime scratch such as worker assignment, journals, prompts, and session logs.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,7 +98,7 @@ flowchart TD
 | `cc-dev` | 已选目标要在当前 worktree 内自动推进到远程 PR | PDCA/IDCA 产物加 PR 或 handoff |
 | `cc-plan` | 新功能或变更需要澄清范围、设计方案、冻结任务 | `planning/tasks.md#Contract Summary`、`task-manifest.json`、`change-meta.json` |
 | `cc-investigate` | Bug 需要症状、复现、根因和修复边界 | `planning/tasks.md#Root Cause Contract`、`task-manifest.json`、`change-meta.json` |
-| `cc-do` | 已计划或已调查的任务需要实现 | 代码、测试、checkpoint、scratch runtime |
+| `cc-do` | 已计划或已调查的任务需要实现 | 代码、测试、任务状态、scratch runtime |
 | `cc-review` | 复杂方案、调查根因或 diff 需要在实现前或验证前做可选深度多轮 Review | `review-ledger.jsonl`，可选 `review-findings.json`，可按需渲染 Markdown |
 | `cc-pr-review` | 远程 PR 需要单独会话做合并前 Review | PR review packet、findings 和 landing verdict |
 | `cc-pr-land` | 已 Review PR 需要 rebase-first 合并到 main 并证明 parity | 已集成 main 和本地 / 远程一致性证据 |
@@ -244,7 +244,7 @@ npx cc-devflow config doctor --cwd /path/to/your/project
 
 - `devflow/specs/` 保存 durable capability truth：`INDEX.md` 和 `capabilities/*.md`。
 - 新 change 目录使用 `REQ-<number>-<description>` 表示需求，使用 `FIX-<number>-<description>` 表示 Bug 修复。`REQ` 和 `FIX` 各自递增自己的编号，跨前缀同号允许共存。并行工作树也可能产生重复编号，必须用完整 change key 的描述区分业务内容。
-- `devflow/changes/<change>/` 保存 durable change truth：`change-meta.json`、`planning/tasks.md`、CLI 生成的 `task-manifest.json`、review ledger / findings 记录、任务级 `checkpoint.json`、`report-card.json` 和唯一最终 handoff 文件。
+- `devflow/changes/<change>/` 保存 durable change truth：`change-meta.json`、`planning/tasks.md`、CLI 生成的 `task-manifest.json`、review ledger / findings 记录、debug / failed 的可选 CLI 日志、`report-card.json` 和唯一最终 handoff 文件。任务级 `context.md`、`checkpoint.json`、review markdown 和 AI 手写过程文件不是默认 durable truth。
 - 新 change 默认只有一个人工编写的 Markdown artifact：`planning/tasks.md`。功能计划把冻结设计写进 `## Contract Summary`；Bug 调查把根因真相写进 `## Root Cause Contract`。历史 `planning/design.md`、`planning/analysis.md` 和 `cc-review-*.md` 只作为旧 change 的 fallback 输入，不再是新默认写入。
 - 用 `cc-devflow task-contract validate`、`npm run verify:artifacts` 和 `npm run benchmark:artifacts` 保持 workflow artifact 小而可测。
 - `devflow/workspaces/<change>/` 保存 ephemeral runtime scratch，例如 worker assignment、journal、prompt 和 session log。

--- a/docs/examples/START-HERE.md
+++ b/docs/examples/START-HERE.md
@@ -140,7 +140,7 @@ That should already tell you:
 
 `devflow/changes/<change>/` should stay lean.
 
-- Durable truth only: `change-meta.json`, `planning/tasks.md`, CLI-generated `task-manifest.json`, review ledger/findings records, task `checkpoint.json`, `report-card.json`, and one final handoff file.
+- Durable truth only: `change-meta.json`, `planning/tasks.md`, CLI-generated `task-manifest.json`, review ledger/findings records, optional CLI logs for debug/failure, `report-card.json`, and one final handoff file. Do not generate task `context.md`, `checkpoint.json`, or AI-written process files.
 - Legacy `planning/design.md`, `planning/analysis.md`, and `cc-review-*.md` are readable fallback inputs for older examples, not new default writes.
 - Runtime scratch belongs in `devflow/workspaces/<change>/`, not beside the durable record.
 

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -6,7 +6,7 @@
     "cc-dev": "1.0.1",
     "cc-plan": "3.9.0",
     "cc-investigate": "1.5.0",
-    "cc-do": "1.6.6",
+    "cc-do": "1.6.7",
     "cc-review": "2.0.0",
     "cc-pr-review": "1.0.0",
     "cc-pr-land": "1.0.0",

--- a/docs/examples/full-design-blocked/README.md
+++ b/docs/examples/full-design-blocked/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.3.0`, `cc-plan@3.9.0`, `cc-do@1.6.6`, `cc-check@1.11.1`
+- Bound skills: `cc-roadmap@5.3.0`, `cc-plan@3.9.0`, `cc-do@1.6.7`, `cc-check@1.11.1`
 
 This example shows a requirement that **looked executable**, but `cc-check` correctly stopped it and sent it back to `cc-plan`.
 

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json
@@ -237,7 +237,7 @@
       ],
       "evidence": [
         "passing test output",
-        "checkpoint summary"
+        "CLI log summary"
       ],
       "context": {
         "readFiles": [

--- a/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
+++ b/docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md
@@ -47,7 +47,7 @@ ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合�
 - Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
 - Task block rule: read the full task block before coding; title-only execution is invalid.
 - Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
-- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+- Completion failure: if the script fails, fix the missing review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
 
 ```bash
 cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --cwd <repo-root> --data-only --no-trace --compact
@@ -68,7 +68,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-b
   Read first: `design.md`, `src/invite/bulk-import.ts`
   Verification: `npm test -- src/invite/bulk-import.test.ts`
   Evidence: failing output
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T001`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T001`; do not hand-edit status.
   Test seam: bulk invite rules and admin upload UI behavior
   Public verification path: Run the bulk invite rule and admin panel tests through their public flows
   Allowed mocks: file upload boundary / billing / seat limit boundary
@@ -80,8 +80,8 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-b
   Files: `src/invite/bulk-import.ts`
   Read first: `design.md`, `src/invite/bulk-import.test.ts`
   Verification: `npm test -- src/invite/bulk-import.test.ts`
-  Evidence: passing output + checkpoint
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T002`; do not hand-edit status.
+  Evidence: passing output + Git diff
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T002`; do not hand-edit status.
   Test seam: bulk invite rules and admin upload UI behavior
   Public verification path: Run the bulk invite rule and admin panel tests through their public flows
   Allowed mocks: file upload boundary / billing / seat limit boundary
@@ -96,7 +96,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-b
   Read first: `design.md`, `src/admin/BulkInvitePanel.tsx`
   Verification: `npm test -- src/admin/BulkInvitePanel.test.tsx`
   Evidence: failing output
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T003`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T003`; do not hand-edit status.
   Test seam: bulk invite rules and admin upload UI behavior
   Public verification path: Run the bulk invite rule and admin panel tests through their public flows
   Allowed mocks: file upload boundary / billing / seat limit boundary
@@ -109,7 +109,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-b
   Read first: `design.md`, `src/admin/BulkInvitePanel.test.tsx`
   Verification: `npm test -- src/admin/BulkInvitePanel.test.tsx`
   Evidence: passing output + review notes
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T004`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T004`; do not hand-edit status.
   Test seam: bulk invite rules and admin upload UI behavior
   Public verification path: Run the bulk invite rule and admin panel tests through their public flows
   Allowed mocks: file upload boundary / billing / seat limit boundary
@@ -126,7 +126,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-b
   - `npm test -- src/invite/bulk-import.test.ts`
   - `npm test -- src/admin/BulkInvitePanel.test.tsx`
   Evidence: passing output + review notes
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T005`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/task-manifest.json --tasks docs/examples/full-design-blocked/changes/REQ-002-bulk-invite-import/planning/tasks.md --task T005`; do not hand-edit status.
   Test seam: bulk invite rules and admin upload UI behavior
   Public verification path: Run the bulk invite rule and admin panel tests through their public flows
   Allowed mocks: file upload boundary / billing / seat limit boundary

--- a/docs/examples/local-handoff/README.md
+++ b/docs/examples/local-handoff/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.3.0`, `cc-plan@3.9.0`, `cc-do@1.6.6`, `cc-check@1.11.1`, `cc-act@1.8.8`
+- Bound skills: `cc-roadmap@5.3.0`, `cc-plan@3.9.0`, `cc-do@1.6.7`, `cc-check@1.11.1`, `cc-act@1.8.8`
 
 This example shows verified work that is **ready to move forward**, but `cc-act` still chooses `local-handoff`.
 

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json
@@ -174,7 +174,7 @@
       ],
       "evidence": [
         "passing test output",
-        "checkpoint summary"
+        "CLI log summary"
       ],
       "context": {
         "readFiles": [

--- a/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
+++ b/docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md
@@ -46,7 +46,7 @@ ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合�
 - Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
 - Task block rule: read the full task block before coding; title-only execution is invalid.
 - Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
-- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+- Completion failure: if the script fails, fix the missing review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
 
 ```bash
 cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --cwd <repo-root> --data-only --no-trace --compact
@@ -67,7 +67,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff
   Read first: `design.md`, `src/admin/AuditSummaryPanel.tsx`
   Verification: `npm test -- src/admin/AuditSummaryPanel.test.tsx`
   Evidence: failing output
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T001`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T001`; do not hand-edit status.
   Test seam: admin audit panel UI behavior
   Public verification path: Run the audit summary panel test and observe CSV export through visible rows
   Allowed mocks: download / blob boundary
@@ -79,8 +79,8 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff
   Files: `src/admin/AuditSummaryPanel.tsx`
   Read first: `design.md`, `src/admin/AuditSummaryPanel.test.tsx`
   Verification: `npm test -- src/admin/AuditSummaryPanel.test.tsx`
-  Evidence: passing output + checkpoint
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T002`; do not hand-edit status.
+  Evidence: passing output + Git diff
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T002`; do not hand-edit status.
   Test seam: admin audit panel UI behavior
   Public verification path: Run the audit summary panel test and observe CSV export through visible rows
   Allowed mocks: download / blob boundary
@@ -97,7 +97,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff
   - `npm test -- src/admin/AuditSummaryPanel.test.tsx`
   - `npm run lint -- src/admin/AuditSummaryPanel.tsx`
   Evidence: passing output + clean lint output
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T003`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/task-manifest.json --tasks docs/examples/local-handoff/changes/REQ-003-audit-log-export/planning/tasks.md --task T003`; do not hand-edit status.
   Test seam: admin audit panel UI behavior
   Public verification path: Run the audit summary panel test and observe CSV export through visible rows
   Allowed mocks: download / blob boundary

--- a/docs/examples/pdca-loop/README.md
+++ b/docs/examples/pdca-loop/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.3.0`, `cc-plan@3.9.0`, `cc-do@1.6.6`, `cc-check@1.11.1`, `cc-act@1.8.8`
+- Bound skills: `cc-roadmap@5.3.0`, `cc-plan@3.9.0`, `cc-do@1.6.7`, `cc-check@1.11.1`, `cc-act@1.8.8`
 
 This folder shows one minimal but complete `cc-roadmap -> cc-plan -> cc-do -> cc-check -> cc-act` loop.
 

--- a/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
+++ b/docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md
@@ -49,7 +49,7 @@ ClaudeCode / Codex 执行本计划时，必须把本文件当成任务模板合�
 - Task selection: read `planning/task-manifest.json.currentTaskId`; if empty, run the ready-task selector before choosing work.
 - Task block rule: read the full task block before coding; title-only execution is invalid.
 - Completion rule: after verification and review gates pass, run the completion script; do not manually edit checkbox, status, or `currentTaskId`.
-- Completion failure: if the script fails, fix the missing checkpoint / review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
+- Completion failure: if the script fails, fix the missing review / dependency evidence and rerun it. Do not bypass it by editing JSON or Markdown.
 
 ```bash
 cc-devflow query workflow-context --change <changeId> --change-key <changeKey> --cwd <repo-root> --data-only --no-trace --compact
@@ -70,7 +70,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/cha
   Read first: `design.md`, `src/features/share/ShareDialog.tsx`
   Verification: `npm test -- src/features/share/ShareDialog.test.tsx`
   Evidence: failing output that shows the missing button / action
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T001`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T001`; do not hand-edit status.
   Test seam: share dialog UI behavior
   Public verification path: Run the share dialog test and observe the copy action through the rendered dialog
   Allowed mocks: clipboard boundary
@@ -82,8 +82,8 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/cha
   Files: `src/features/share/ShareDialog.tsx`
   Read first: `design.md`, `src/features/share/ShareDialog.test.tsx`
   Verification: `npm test -- src/features/share/ShareDialog.test.tsx`
-  Evidence: passing output + checkpoint + review notes
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T002`; do not hand-edit status.
+  Evidence: passing output + review notes
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T002`; do not hand-edit status.
   Test seam: share dialog UI behavior
   Public verification path: Run the share dialog test and observe the copy action through the rendered dialog
   Allowed mocks: clipboard boundary
@@ -100,7 +100,7 @@ bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/cha
   - `npm test -- src/features/share/ShareDialog.test.tsx`
   - `npm run lint -- src/features/share/ShareDialog.tsx`
   Evidence: passing test output + clean lint output
-  Completion: after verification evidence and required checkpoint/review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T003`; do not hand-edit status.
+  Completion: after verification evidence and required review records exist, run `SCRIPT_ROOT=".claude/skills/cc-do/scripts"; if [[ ! -d "$SCRIPT_ROOT" && -d ".codex/skills/cc-do/scripts" ]]; then SCRIPT_ROOT=".codex/skills/cc-do/scripts"; fi; bash "$SCRIPT_ROOT/mark-task-complete.sh" --manifest docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/task-manifest.json --tasks docs/examples/pdca-loop/changes/REQ-001-copy-invite-link/planning/tasks.md --task T003`; do not hand-edit status.
   Test seam: share dialog UI behavior
   Public verification path: Run the share dialog test and observe the copy action through the rendered dialog
   Allowed mocks: clipboard boundary

--- a/docs/get-shit-done-strategy-audit.md
+++ b/docs/get-shit-done-strategy-audit.md
@@ -140,10 +140,10 @@ No separate GSD-style `.planning/` tree.
 | --- | --- | --- | --- |
 | Wave scheduling | `task-manifest.json.tasks[].phase/parallel/dependsOn/touches` | parallel only when dependencies and touches do not conflict | schema fixture: shared touches rejected |
 | Submodule-aware worktree gate | `task-manifest.json.tasks[].touches` + runtime submodule scan | only tasks touching submodule paths lose isolation | hostile fixture: repo with `.gitmodules` but unrelated touches still parallel |
-| Quick lane mini manifest | `task-manifest.json.metadata.lane=quick` | small work still has checkpoint, verification, handoff | fixture: quick lane without verification blocks |
-| Thread/pause/resume | `change-meta.json`, checkpoint state, and one final handoff file | resume query returns stable next action | integration: stale checkpoint restores to pending |
+| Quick lane mini manifest | `task-manifest.json.metadata.lane=quick` | small work still has task-state truth, verification, handoff | fixture: quick lane without verification blocks |
+| Thread/pause/resume | `change-meta.json`, manifest task state, optional CLI logs, and one final handoff file | resume query returns stable next action | integration: stale manifest state restores to pending |
 
-`cc-do` should not invent new task state outside `task-manifest.json` and checkpoints.
+`cc-do` should not invent new task state outside `task-manifest.json`.
 
 ### `cc-investigate`
 
@@ -211,7 +211,7 @@ default planning path.
 | Ambiguity and assumptions | `cc-plan` | `planning/tasks.md#Contract Summary` | `task-manifest.json.planningMeta` |
 | Imported doc trust classification | `cc-plan` | `planning/tasks.md#Contract Summary` | `planning/tasks.md` |
 | Task graph and waves | `cc-plan` / `cc-do` | `planning/tasks.md` | `task-manifest.json.tasks[]` |
-| Quick lane state | `cc-do` | checkpoint summary | `task-manifest.json.metadata`, `checkpoint.json` |
+| Quick lane state | `cc-do` | task-state summary | `task-manifest.json.metadata`, `planning/tasks.md` |
 | Debug hypotheses and probes | `cc-investigate` | `planning/tasks.md#Root Cause Contract` | optional `task-manifest.json.investigation` |
 | Verification/UAT/facets | `cc-check` | review summary | `report-card.json` |
 | Runtime failures | `cc-check` | review summary | `report-card.json.runtime.failureOwnership[]` |
@@ -243,7 +243,7 @@ owner skill, and next action.
 | --- | --- | --- | --- | --- | --- | --- |
 | external docs -> `cc-plan` | block with missing source | skip with reason | `TrustBoundaryError` | conflict bucket | mark stale source | partial import warning |
 | `tasks.md` -> `task-manifest.json` | block | block | schema error | dependency conflict | plan version mismatch | no manifest approval |
-| manifest -> wave scheduling | block | no runnable task | `InvalidTaskGraphError` | serialize or block | stale checkpoint rejected | reroute resume |
+| manifest -> wave scheduling | block | no runnable task | `InvalidTaskGraphError` | serialize or block | stale manifest state rejected | reroute resume |
 | debug session -> analysis | block freeze | require note | schema/narrative mismatch | competing hypotheses | stale symptom | diagnose-only |
 | query registry -> next action | `MissingArtifactError` | no next action with reason | named parse/schema error | blocked graph | stale state warning | degraded output |
 | inventory -> publish gate | missing inventory blocks | empty inventory blocks | schema error | drift blocks | stale hash blocks | publish blocked |
@@ -354,7 +354,7 @@ These rules protect cc-devflow's identity:
 | Existing cc-devflow asset | Reuse |
 | --- | --- |
 | `lib/skill-runtime/query.js` | current progress/next/full-state facade |
-| `lib/skill-runtime/schemas.js` | manifest/report/checkpoint schema boundary |
+| `lib/skill-runtime/schemas.js` | manifest/report/runtime schema boundary |
 | `lib/skill-runtime/config.js` | layered config and doctor pattern |
 | `lib/compiler/manifest.js` | hash and drift detection foundation |
 | `scripts/validate-publish.js` | publish validation orchestrator |
@@ -404,7 +404,7 @@ not the cc-devflow implementation order.
 | `ship` | structured ship preflight |
 | `next` | runtime query `route.next-action` |
 | `fast` | TDD exception / quick lane rule |
-| `quick` | mini manifest + checkpoint |
+| `quick` | mini manifest + task-state truth |
 | `ui-review` | conditional frontend `cc-check` facet |
 | `code-review` | finding schema |
 | `code-review-fix` | fix loop and return to `cc-check` |
@@ -433,7 +433,7 @@ not the cc-devflow implementation order.
 | `cleanup` | low priority cleanup |
 | `manager` | skip UI |
 | `workstreams` | active pointer only |
-| `autonomous` | smart-discuss/checkpoint guard only |
+| `autonomous` | smart-discuss/task-state guard only |
 | `undo` | rollback guard |
 
 ### Session And Navigation

--- a/docs/guides/artifact-contract.md
+++ b/docs/guides/artifact-contract.md
@@ -20,7 +20,7 @@ If a field has no clear opener and no downstream consumer, remove it.
 | Capability/spec sync state | `devflow/changes/<change-key>/change-meta.json` | `planning/tasks.md`, `review/report-card.json`, handoff summaries |
 | Execution task status | `planning/task-manifest.json.tasks[].status` | `planning/tasks.md` checkboxes, recovery summaries |
 | Ready task / phase | derived from `tasks[].status`, `tasks[].phase`, and `tasks[].dependsOn` | `currentTaskId` cache, ready-task selector output |
-| Runtime checkpoint state | `execution/tasks/<task-id>/checkpoint.json` | `events.jsonl`, recovery summaries |
+| Runtime event log | `execution/tasks/<task-id>/events.jsonl` only for debug/failed runs | recovery summaries |
 | Review verdict | `review/report-card.json.verdict` | PR brief, release note, act gate |
 | PR / remote queue truth | live GitHub API / `gh` output | local review notes and handoff summaries |
 | Project postmortem facts and principles | `devflow/postmortems/` | planning recall, investigation hypotheses, task guardrails |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -98,7 +98,7 @@ Change truth lives in `devflow/changes/<change>/`.
 
 - Keep `INDEX.md` plus capability markdown under `devflow/specs/`.
 - Name new change directories as `REQ-<number>-<description>` for requirements or `FIX-<number>-<description>` for bug fixes. `REQ` and `FIX` advance as separate local sequences, so cross-prefix duplicates are valid. Parallel worktrees may still repeat numbers; the full change key, especially the description, distinguishes the work. Old lowercase directories are compatibility reads only.
-- Keep `change-meta.json`, `planning/tasks.md`, CLI-generated `task-manifest.json`, review ledger/findings records, task `checkpoint.json`, `report-card.json`, and one final handoff file under each `devflow/changes/<change>/`.
+- Keep `change-meta.json`, `planning/tasks.md`, CLI-generated `task-manifest.json`, review ledger/findings records, optional CLI logs for debug/failure, `report-card.json`, and one final handoff file under each `devflow/changes/<change>/`. Do not generate task `context.md`, `checkpoint.json`, or AI-written process files.
 - Legacy `planning/design.md`, `planning/analysis.md`, and `cc-review-*.md` are readable fallback inputs for older changes, not new default writes.
 - Worker prompts, journals, assignments, and session logs belong under `devflow/workspaces/<change>/` as ephemeral scratch.
 

--- a/docs/guides/getting-started.zh-CN.md
+++ b/docs/guides/getting-started.zh-CN.md
@@ -97,7 +97,7 @@ durable truth 分两层：
 
 - `devflow/specs/`：capability 真相，保留 `INDEX.md` 与 `capabilities/*.md`
 - 新 change 目录必须命名为 `REQ-<number>-<description>`（需求）或 `FIX-<number>-<description>`（修复）；`REQ` 和 `FIX` 分别维护自己的递增编号，跨前缀同号不是冲突；并行工作树造成重复编号时，完整 change key 的描述负责区分业务内容，旧小写目录只作为历史兼容读取。
-- `devflow/changes/<change>/`：变更真相，保留 `change-meta.json`、`planning/tasks.md`、CLI 生成的 `task-manifest.json`、review ledger / findings 记录、任务级 `checkpoint.json`、`report-card.json` 和唯一的最终 handoff 文件。
+- `devflow/changes/<change>/`：变更真相，保留 `change-meta.json`、`planning/tasks.md`、CLI 生成的 `task-manifest.json`、review ledger / findings 记录、debug / failed 的可选 CLI 日志、`report-card.json` 和唯一的最终 handoff 文件。不要生成任务级 `context.md`、`checkpoint.json` 或 AI 手写过程文件。
 - 历史 `planning/design.md`、`planning/analysis.md` 和 `cc-review-*.md` 是旧 change 的可读 fallback，不再是新默认写入。
 - worker prompt、journal、assignment、session log 统一放到 `devflow/workspaces/<change>/`，作为 ephemeral scratch。
 

--- a/lib/compiler/__tests__/skills-registry.test.js
+++ b/lib/compiler/__tests__/skills-registry.test.js
@@ -159,9 +159,9 @@ describe('Skills Registry Generator', () => {
       expect(execute.writes).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            path: 'devflow/changes/<change-key>/execution/tasks/<task-id>/checkpoint.json',
+            path: 'devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl',
             durability: 'durable',
-            required: true
+            required: false
           })
         ])
       );

--- a/lib/skill-runtime/__tests__/autopilot.test.js
+++ b/lib/skill-runtime/__tests__/autopilot.test.js
@@ -9,8 +9,7 @@ const {
   getTaskManifestPath,
   getReportCardPath,
   getReleaseNotePath,
-  getRuntimeStatePath,
-  getCheckpointPath
+  getRuntimeStatePath
 } = require('../store');
 const {
   getIntentResumeIndexPath,
@@ -117,7 +116,7 @@ describe('runAutopilot', () => {
     expect(fs.existsSync(getIntentResumeIndexPath(repoRoot, 'REQ-123'))).toBe(false);
   });
 
-  test('resumes after approval, executes delegated work, and prepares a PR from checkpoints', async () => {
+  test('resumes after approval, executes delegated work, and prepares a PR from task state', async () => {
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-devflow-autopilot-workers-'));
 
     writeJson(path.join(repoRoot, 'package.json'), {
@@ -159,13 +158,11 @@ describe('runAutopilot', () => {
     });
 
     const manifest = JSON.parse(fs.readFileSync(getTaskManifestPath(repoRoot, 'REQ-123'), 'utf8'));
-    const delegatedCheckpoint = JSON.parse(fs.readFileSync(getCheckpointPath(repoRoot, 'REQ-123', 'T002'), 'utf8'));
     const report = JSON.parse(fs.readFileSync(getReportCardPath(repoRoot, 'REQ-123'), 'utf8'));
 
     expect(firstRun.executed).toEqual(expect.arrayContaining(['delegate', 'worker-run', 'dispatch', 'verify']));
     expect(firstRun.currentStage).toBe('verify');
     expect(manifest.tasks.find((task) => task.id === 'T002').status).toBe('passed');
-    expect(delegatedCheckpoint.outputExcerpt).toContain('delegate-ok');
     expect(report.review.status).toBe('blocked');
     expect(fs.existsSync(getIntentPrBriefPath(repoRoot, 'REQ-123'))).toBe(false);
 
@@ -183,7 +180,8 @@ describe('runAutopilot', () => {
 
     expect(secondRun.executed).toEqual(expect.arrayContaining(['verify', 'prepare-pr']));
     expect(secondRun.currentStage).toBe('prepare-pr');
-    expect(prBrief).toContain('execution/tasks/T002/checkpoint.json');
+    expect(prBrief).toContain('planning/task-manifest.json');
+    expect(prBrief).not.toContain('checkpoint.json');
   });
 
   test('runs release after prepare-pr when requested for an approved plan', async () => {

--- a/lib/skill-runtime/__tests__/cli-bootstrap.integration.test.js
+++ b/lib/skill-runtime/__tests__/cli-bootstrap.integration.test.js
@@ -217,9 +217,9 @@ describe('cc-devflow cli distribution bootstrap', () => {
     expect(codexDoSkill.data.writes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          path: 'devflow/changes/<change-key>/execution/tasks/<task-id>/checkpoint.json',
+          path: 'devflow/changes/<change-key>/execution/tasks/<task-id>/events.jsonl',
           durability: 'durable',
-          required: true
+          required: false
         })
       ])
     );

--- a/lib/skill-runtime/__tests__/dispatch.test.js
+++ b/lib/skill-runtime/__tests__/dispatch.test.js
@@ -7,7 +7,6 @@ const { runResume } = require('../operations/resume');
 const {
   getRuntimeStatePath,
   getTaskManifestPath,
-  getCheckpointPath,
   getEventsPath
 } = require('../store');
 
@@ -76,7 +75,7 @@ describe('runDispatch', () => {
     expect(nextManifest.tasks[0].status).toBe('pending');
   });
 
-  test('rejects stale results when planVersion changes during task execution and records it in checkpoint', async () => {
+  test('rejects stale results when planVersion changes during task execution and records it in manifest and events', async () => {
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-devflow-dispatch-'));
     const manifestPath = getTaskManifestPath(repoRoot, 'REQ-123');
 
@@ -133,28 +132,25 @@ describe('runDispatch', () => {
     });
 
     const nextManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    const checkpoint = JSON.parse(fs.readFileSync(getCheckpointPath(repoRoot, 'REQ-123', 'T001'), 'utf8'));
     const events = fs.readFileSync(getEventsPath(repoRoot, 'REQ-123', 'T001'), 'utf8');
 
     expect(result.success).toBe(false);
     expect(nextManifest.tasks[0].status).toBe('failed');
     expect(nextManifest.tasks[0].lastError).toContain('Stale result rejected');
-    expect(checkpoint.planVersion).toBe(1);
-    expect(checkpoint.error).toContain('Stale result rejected');
     expect(events).toContain('task_stale_rejected');
   });
 
-  test('restores unresolved work from the latest stable checkpoint on resume without creating handoff markdown', async () => {
+  test('restores unresolved work from the latest stable manifest state on resume without creating handoff markdown', async () => {
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-devflow-resume-stable-'));
     const changeId = 'REQ-123';
     const manifestPath = getTaskManifestPath(repoRoot, changeId);
 
     writeJson(getRuntimeStatePath(repoRoot, changeId), {
       changeId,
-      changeKey: 'REQ-123-recover-from-stable-checkpoint',
-      slug: 'recover-from-stable-checkpoint',
+      changeKey: 'REQ-123-recover-from-stable-state',
+      slug: 'recover-from-stable-state',
       createdAt: '2026-04-09T01:00:00.000Z',
-      goal: 'Recover from stable checkpoint',
+      goal: 'Recover from stable state',
       status: 'in_progress',
       initializedAt: '2026-04-09T01:00:00.000Z',
       plannedAt: '2026-04-09T01:01:00.000Z',
@@ -169,13 +165,13 @@ describe('runDispatch', () => {
 
     writeJson(manifestPath, {
       changeId,
-      goal: 'Recover from stable checkpoint',
+      goal: 'Recover from stable state',
       createdAt: '2026-04-09T01:00:00.000Z',
       updatedAt: '2026-04-09T01:02:00.000Z',
       tasks: [
         {
           id: 'T001',
-          title: 'Stable checkpoint task',
+          title: 'Stable completed task',
           type: 'TEST',
           dependsOn: [],
           touches: ['src/a.ts'],
@@ -219,32 +215,6 @@ describe('runDispatch', () => {
       }
     });
 
-    writeJson(getCheckpointPath(repoRoot, changeId, 'T001'), {
-      changeId,
-      taskId: 'T001',
-      sessionId: 'stable-session',
-      planVersion: 1,
-      status: 'passed',
-      summary: 'Task passed after 1 attempt(s)',
-      error: '',
-      outputExcerpt: '',
-      timestamp: '2026-04-09T01:05:00.000Z',
-      attempt: 1
-    });
-
-    writeJson(getCheckpointPath(repoRoot, changeId, 'T002'), {
-      changeId,
-      taskId: 'T002',
-      sessionId: 'failed-session',
-      planVersion: 1,
-      status: 'failed',
-      summary: 'Task failed: Command failed',
-      error: 'Command failed',
-      outputExcerpt: 'Command failed',
-      timestamp: '2026-04-09T01:06:00.000Z',
-      attempt: 2
-    });
-
     const result = await runResume({
       repoRoot,
       changeId,
@@ -255,7 +225,7 @@ describe('runDispatch', () => {
     const nextManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
     expect(result.success).toBe(true);
-    expect(result.restoredCheckpoint).toMatchObject({
+    expect(result.restoredState).toMatchObject({
       taskId: 'T001',
       status: 'passed'
     });

--- a/lib/skill-runtime/__tests__/intent.test.js
+++ b/lib/skill-runtime/__tests__/intent.test.js
@@ -15,8 +15,7 @@ const {
 const {
   getRuntimeStatePath,
   getTaskManifestPath,
-  getReportCardPath,
-  getCheckpointPath
+  getReportCardPath
 } = require('../store');
 
 function writeJson(filePath, value) {
@@ -86,21 +85,6 @@ describe('intent handoff bridge', () => {
       }
     );
 
-    writeJson(
-      getCheckpointPath(repoRoot, 'REQ-123', 'T001'),
-      {
-        changeId: 'REQ-123',
-        taskId: 'T001',
-        sessionId: 'T001-session',
-        planVersion: 1,
-        status: 'passed',
-        summary: 'Task passed after 1 attempt',
-        error: '',
-        outputExcerpt: 'worker-ok',
-        timestamp: '2026-03-25T01:11:00.000Z',
-        attempt: 1
-      }
-    );
   });
 
   test('syncIntentMemory removes legacy projection files instead of writing them', async () => {
@@ -152,7 +136,7 @@ describe('intent handoff bridge', () => {
     }
   });
 
-  test('writes pr brief from manifest, checkpoints, and report-card only', async () => {
+  test('writes pr brief from manifest task state and report-card only', async () => {
     const prBriefPath = getIntentPrBriefPath(repoRoot, 'REQ-123');
     const manifestPath = getTaskManifestPath(repoRoot, 'REQ-123');
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
@@ -208,8 +192,8 @@ describe('intent handoff bridge', () => {
 
     expect(prBrief).toContain('PR Brief: REQ-123');
     expect(prBrief).toContain('Suggested Title: feat(req-123): Deliver autopilot memory bridge');
-    expect(prBrief).toContain('execution/tasks/T001/checkpoint.json');
-    expect(prBrief).toContain('execution/tasks/T002/checkpoint.json');
+    expect(prBrief).toContain('planning/tasks.md');
+    expect(prBrief).toContain('planning/task-manifest.json');
     expect(prBrief).toContain('存在 1 个 skipped 任务，需要确认是否可接受：T002');
     expect(prBrief).not.toContain('result.md');
     for (const filePath of getIntentHandoffArtifactPaths(repoRoot, 'REQ-123')) {

--- a/lib/skill-runtime/__tests__/lifecycle.test.js
+++ b/lib/skill-runtime/__tests__/lifecycle.test.js
@@ -104,7 +104,7 @@ describe('lifecycle helpers', () => {
     };
 
     expect(deriveLifecycleNextAction({ state: approvedState, manifest, report: null })).toBe(
-      '优先修复失败任务 T002，然后从最近稳定 checkpoint 恢复。'
+      '优先修复失败任务 T002，然后从 task-manifest 的最近稳定状态恢复。'
     );
     expect(
       deriveLifecycleNextAction({

--- a/lib/skill-runtime/__tests__/prepare-pr.test.js
+++ b/lib/skill-runtime/__tests__/prepare-pr.test.js
@@ -6,8 +6,7 @@ const { runPreparePr } = require('../operations/prepare-pr');
 const {
   getRuntimeStatePath,
   getTaskManifestPath,
-  getReportCardPath,
-  getCheckpointPath
+  getReportCardPath
 } = require('../store');
 const {
   getIntentPrBriefPath,
@@ -94,19 +93,6 @@ describe('runPreparePr', () => {
       timestamp: '2026-03-25T01:11:00.000Z'
     });
 
-    writeJson(getCheckpointPath(repoRoot, 'REQ-123', 'T001'), {
-      changeId: 'REQ-123',
-      taskId: 'T001',
-      sessionId: 'task-session',
-      planVersion: 1,
-      status: 'passed',
-      summary: 'Task passed after 1 attempt',
-      error: '',
-      outputExcerpt: 'ok',
-      timestamp: '2026-03-25T01:09:00.000Z',
-      attempt: 1
-    });
-
     writeJson(getRuntimeStatePath(repoRoot, 'REQ-123'), {
       ...JSON.parse(fs.readFileSync(getRuntimeStatePath(repoRoot, 'REQ-123'), 'utf8')),
       approval: {
@@ -130,7 +116,8 @@ describe('runPreparePr', () => {
     expect(result.status).toBe('prepared');
     expect(result.suggestedTitle).toBe('feat(req-123): Prepare a PR-ready brief');
     expect(prBrief).toContain('PR Brief: REQ-123');
-    expect(prBrief).toContain('execution/tasks/T001/checkpoint.json');
+    expect(prBrief).toContain('planning/task-manifest.json');
+    expect(prBrief).not.toContain('execution/tasks/T001/checkpoint.json');
     expect(prBrief).not.toContain('result.md');
     for (const filePath of getIntentHandoffArtifactPaths(repoRoot, 'REQ-123')) {
       expect(fs.existsSync(filePath)).toBe(filePath === prBriefPath);

--- a/lib/skill-runtime/__tests__/query.test.js
+++ b/lib/skill-runtime/__tests__/query.test.js
@@ -311,7 +311,7 @@ describe('query helpers', () => {
       updatedAt: '2026-05-12T01:05:00.000Z',
       currentTaskId: 'T002',
       planningMeta: {
-        reqPlanSkillVersion: '3.8.6'
+        reqPlanSkillVersion: '3.8.8'
       },
       tasks: [
         {
@@ -460,7 +460,7 @@ describe('query helpers', () => {
       })
     ]));
     expect(context.planningMeta).toMatchObject({
-      reqPlanSkillVersion: '3.8.6',
+      reqPlanSkillVersion: '3.8.8',
       sourceCapability: 'cap-compact-context',
       specSyncStatus: 'planned'
     });
@@ -735,7 +735,7 @@ describe('query helpers', () => {
       },
       trace: {
         event: 'query.progress.failed',
-        nextAction: 'inspect-runtime-artifacts'
+        nextAction: 'inspect-workflow-artifacts'
       }
     });
 
@@ -781,11 +781,11 @@ describe('query helpers', () => {
         artifactRefs: [
           expect.stringContaining('task-manifest.json')
         ],
-        rescueAction: 'create required runtime artifacts before running this query'
+        rescueAction: 'create required workflow artifacts before running this query'
       },
       trace: {
         event: 'query.progress.failed',
-        nextAction: 'create required runtime artifacts before running this query'
+        nextAction: 'create required workflow artifacts before running this query'
       }
     });
   });
@@ -804,11 +804,11 @@ describe('query helpers', () => {
         artifactRefs: [
           expect.stringContaining('task-manifest.json')
         ],
-        rescueAction: 'repair or regenerate the invalid runtime artifact before running this query'
+        rescueAction: 'repair or regenerate the invalid workflow artifact before running this query'
       },
       trace: {
         event: 'query.progress.failed',
-        nextAction: 'repair or regenerate the invalid runtime artifact before running this query'
+        nextAction: 'repair or regenerate the invalid workflow artifact before running this query'
       }
     });
   });

--- a/lib/skill-runtime/__tests__/runtime.integration.test.js
+++ b/lib/skill-runtime/__tests__/runtime.integration.test.js
@@ -224,7 +224,7 @@ describe('Skill runtime', () => {
     expect(report.blockingFindings.some((item) => item.includes('missing spec review proof'))).toBe(true);
   });
 
-  test('cc-do shell helpers write runtime artifacts into devflow/changes instead of legacy flat paths', async () => {
+  test('cc-do shell helpers keep task truth in manifest and do not write process files by default', async () => {
     const changeId = 'REQ-2001';
     await runInit({ repoRoot, changeId, goal: 'Verify shell helper layout' });
 
@@ -248,7 +248,7 @@ describe('Skill runtime', () => {
       )}\n`
     );
 
-    const checkpoint = spawnSync(WRITE_TASK_CHECKPOINT, [
+    const legacyCheckpoint = spawnSync(WRITE_TASK_CHECKPOINT, [
       '--dir',
       change.changeDir,
       '--task',
@@ -256,24 +256,9 @@ describe('Skill runtime', () => {
       '--status',
       'passed',
       '--summary',
-      'task finished',
-      '--tdd-json',
-      JSON.stringify({
-        red: {
-          testSeam: 'public helper command',
-          behaviorAsserted: 'checkpoint is written under execution/tasks',
-          allowedMocks: [],
-          implementationDetailRisk: 'low'
-        },
-        testQuality: {
-          usesPublicInterface: true,
-          describesBehavior: true,
-          survivesInternalRefactor: true,
-          mocksOnlySystemBoundaries: true
-        }
-      })
+      'task finished'
     ], { encoding: 'utf8' });
-    expect(checkpoint.status).toBe(0);
+    expect(legacyCheckpoint.status).toBe(0);
 
     const specReview = spawnSync(RECORD_REVIEW_DECISION, [
       '--dir',
@@ -311,10 +296,25 @@ describe('Skill runtime', () => {
     ], { encoding: 'utf8' });
     expect(verify.status).toBe(0);
 
-    expect(fs.existsSync(path.join(change.tasksDir, 'T001', 'checkpoint.json'))).toBe(true);
-    const checkpointJson = JSON.parse(fs.readFileSync(path.join(change.tasksDir, 'T001', 'checkpoint.json'), 'utf8'));
-    expect(checkpointJson.tdd.red.testSeam).toBe('public helper command');
-    expect(checkpointJson.tdd.testQuality.usesPublicInterface).toBe(true);
+    const complete = spawnSync(MARK_TASK_COMPLETE, [
+      '--manifest',
+      manifestPath,
+      '--task',
+      'T001'
+    ], { encoding: 'utf8' });
+    expect(complete.status).toBe(0);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(manifest.currentTaskId).toBeNull();
+    expect(manifest.tasks[0]).toMatchObject({
+      id: 'T001',
+      status: 'passed',
+      reviews: { spec: 'pass', code: 'pass' }
+    });
+
+    expect(fs.existsSync(path.join(change.tasksDir, 'T001', 'checkpoint.json'))).toBe(false);
+    expect(fs.existsSync(path.join(change.tasksDir, 'T001', 'context.md'))).toBe(false);
+    expect(fs.existsSync(path.join(change.tasksDir, 'T001', 'events.jsonl'))).toBe(false);
     expect(fs.existsSync(path.join(repoRoot, '.harness', 'runtime', changeId))).toBe(false);
     expect(fs.existsSync(path.join(change.tasksDir, 'T001', 'checkpoint.md'))).toBe(false);
     expect(fs.existsSync(path.join(change.tasksDir, 'T001', 'review-spec.md'))).toBe(false);

--- a/lib/skill-runtime/__tests__/worker-run.test.js
+++ b/lib/skill-runtime/__tests__/worker-run.test.js
@@ -11,7 +11,6 @@ const {
 const {
   getRuntimeStatePath,
   getTaskManifestPath,
-  getCheckpointPath,
   getEventsPath
 } = require('../store');
 
@@ -138,7 +137,7 @@ describe('runWorkerCommand', () => {
     expect(claudeCommand).toContain('--dangerously-skip-permissions');
   });
 
-  test('runs local worker command and records only checkpoint truth by default', async () => {
+  test('runs local worker command and records only task status truth by default', async () => {
     const repoRoot = setupRepoRoot('cc-devflow-worker-run-pass-');
     const manifest = createManifest();
     writeManifest(repoRoot, manifest);
@@ -157,7 +156,6 @@ describe('runWorkerCommand', () => {
     const log = fs.readFileSync(result.sessionLogPath, 'utf8');
     const bus = fs.readFileSync(getMessageBusPath(repoRoot, 'REQ-123'), 'utf8');
     const assignment = fs.readFileSync(getWorkerAssignmentPath(repoRoot, 'REQ-123', workerId), 'utf8');
-    const checkpoint = JSON.parse(fs.readFileSync(getCheckpointPath(repoRoot, 'REQ-123', 'T002'), 'utf8'));
     const nextManifest = JSON.parse(fs.readFileSync(getTaskManifestPath(repoRoot, 'REQ-123'), 'utf8'));
     const runtimeState = JSON.parse(fs.readFileSync(getRuntimeStatePath(repoRoot, 'REQ-123'), 'utf8'));
 
@@ -167,9 +165,6 @@ describe('runWorkerCommand', () => {
     expect(log).toContain('worker-ok');
     expect(bus).toContain(`${workerId} completed T002`);
     expect(assignment).toContain('`T002` status=`completed`');
-    expect(checkpoint.status).toBe('passed');
-    expect(checkpoint.outputExcerpt).toContain('worker-ok');
-    expect(checkpoint.error).toBe('');
     expect(fs.existsSync(getEventsPath(repoRoot, 'REQ-123', 'T002'))).toBe(false);
     expect(fs.existsSync(path.join(repoRoot, 'devflow/changes/REQ-123-run-delegated-worker-command/execution/workers'))).toBe(false);
     expect(nextManifest.tasks[0].status).toBe('passed');
@@ -192,7 +187,7 @@ describe('runWorkerCommand', () => {
     expect(providerPrompt).toContain('Delegated task');
   });
 
-  test('writes failure events and checkpoint error when local command exits non-zero', async () => {
+  test('writes failure events and manifest error when local command exits non-zero', async () => {
     const repoRoot = setupRepoRoot('cc-devflow-worker-run-fail-');
     const manifest = createManifest();
     writeManifest(repoRoot, manifest);
@@ -210,7 +205,6 @@ describe('runWorkerCommand', () => {
     const log = fs.readFileSync(result.sessionLogPath, 'utf8');
     const assignment = fs.readFileSync(getWorkerAssignmentPath(repoRoot, 'REQ-123', workerId), 'utf8');
     const failedManifest = JSON.parse(fs.readFileSync(getTaskManifestPath(repoRoot, 'REQ-123'), 'utf8'));
-    const checkpoint = JSON.parse(fs.readFileSync(getCheckpointPath(repoRoot, 'REQ-123', 'T002'), 'utf8'));
     const events = fs.readFileSync(getEventsPath(repoRoot, 'REQ-123', 'T002'), 'utf8');
 
     expect(result.status).toBe('failed');
@@ -218,10 +212,9 @@ describe('runWorkerCommand', () => {
     expect(state).toContain('Status: `failed`');
     expect(log).toContain('boom');
     expect(assignment).toContain('`T002` status=`failed`');
-    expect(checkpoint.status).toBe('failed');
-    expect(checkpoint.error).toContain('boom');
     expect(events).toContain('worker_run_failed');
     expect(failedManifest.tasks[0].status).toBe('failed');
+    expect(failedManifest.tasks[0].lastError).toContain('boom');
   });
 
   test('updates only the selected task when a worker owns multiple assignments', async () => {
@@ -277,6 +270,6 @@ describe('runWorkerCommand', () => {
     });
 
     expect(fs.existsSync(path.join(repoRoot, 'blocked.txt'))).toBe(false);
-    expect(fs.existsSync(getCheckpointPath(repoRoot, 'REQ-123', 'T002'))).toBe(false);
+    expect(fs.existsSync(getEventsPath(repoRoot, 'REQ-123', 'T002'))).toBe(false);
   });
 });

--- a/lib/skill-runtime/__tests__/workflow-context-legacy-fallback.test.js
+++ b/lib/skill-runtime/__tests__/workflow-context-legacy-fallback.test.js
@@ -13,7 +13,6 @@ const repoRoot = path.resolve(__dirname, '../../..');
 
 describe('workflow-context legacy fallback refs', () => {
   test.each([
-    ['REQ-001', 'REQ-001-personal-output-config'],
     ['REQ-002', 'REQ-002-unified-roadmap-truth']
   ])('%s keeps design.md as the first fallback contract ref', async (changeId, changeKey) => {
     const context = await getWorkflowContext(repoRoot, changeId, { changeKey });

--- a/lib/skill-runtime/artifacts.js
+++ b/lib/skill-runtime/artifacts.js
@@ -16,10 +16,6 @@ function getIntentArtifactsDir(repoRoot, goalId, options = {}) {
   return getChangePaths(repoRoot, goalId, options).executionDir;
 }
 
-function getIntentCheckpointsDir(repoRoot, goalId, options = {}) {
-  return getChangePaths(repoRoot, goalId, options).tasksDir;
-}
-
 function getIntentResumeIndexPath(repoRoot, goalId, options = {}) {
   return `${getChangePaths(repoRoot, goalId, options).handoffDir}/resume-index.md`;
 }
@@ -83,7 +79,6 @@ async function ensureIntentScaffold(repoRoot, goalId, options = {}) {
 module.exports = {
   getIntentDir,
   getIntentArtifactsDir,
-  getIntentCheckpointsDir,
   getIntentResumeIndexPath,
   getIntentPrBriefPath,
   getIntentStatusPath,

--- a/lib/skill-runtime/context-index.js
+++ b/lib/skill-runtime/context-index.js
@@ -421,7 +421,6 @@ async function buildSourceIndex({
   tasksPath,
   changeMetaPath,
   reportPath,
-  checkpointPath,
   refs
 }) {
   const entries = {
@@ -444,10 +443,6 @@ async function buildSourceIndex({
     reportCard: refs.relativeReportPath ? {
       path: refs.relativeReportPath,
       hash: await hashFile(reportPath)
-    } : null,
-    checkpoint: refs.relativeCheckpointPath ? {
-      path: refs.relativeCheckpointPath,
-      hash: await hashFile(checkpointPath)
     } : null
   };
 

--- a/lib/skill-runtime/intent.js
+++ b/lib/skill-runtime/intent.js
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: 依赖 store 的路径与文件读写能力，依赖 change-state/task-manifest/report-card/checkpoint 作为 durable truth。
+ * [INPUT]: 依赖 store 的路径与文件读写能力，依赖 change-state/task-manifest/report-card 作为 durable truth。
  * [OUTPUT]: 对外提供 handoff 级工件生成与 legacy artifact 清理能力。
  * [POS]: skill runtime 的薄 handoff 层，只保留终态交付文件，不再投影中间态 Markdown。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
@@ -14,7 +14,6 @@ const {
   getRuntimeStatePath,
   getTaskManifestPath,
   getReportCardPath,
-  getCheckpointPath,
   getReleaseNotePath
 } = require('./store');
 const {
@@ -68,28 +67,6 @@ function summarizeGateSection(gates = []) {
   });
 }
 
-async function readLatestCheckpoints(repoRoot, changeId, tasks = [], options = {}) {
-  const checkpoints = [];
-
-  for (const task of tasks) {
-    const checkpoint = await readJson(getCheckpointPath(repoRoot, changeId, task.id, options), null);
-    if (!checkpoint) {
-      continue;
-    }
-
-    checkpoints.push({
-      taskId: task.id,
-      title: task.title,
-      status: checkpoint.status,
-      timestamp: checkpoint.timestamp,
-      summary: checkpoint.summary
-    });
-  }
-
-  checkpoints.sort((left, right) => right.timestamp.localeCompare(left.timestamp));
-  return checkpoints;
-}
-
 async function cleanupLegacyArtifacts(repoRoot, changeId, manifest, options = {}) {
   const taskIds = (manifest?.tasks || []).map((task) => task.id);
   const change = getChangePaths(repoRoot, changeId, options);
@@ -111,8 +88,7 @@ async function clearHandoffArtifacts(repoRoot, changeId, keep = null, options = 
 async function writeResumeIndex(repoRoot, changeId, state, manifest, report, options = {}) {
   await ensureIntentScaffold(repoRoot, changeId, options);
 
-  const checkpoints = await readLatestCheckpoints(repoRoot, changeId, manifest?.tasks || [], options);
-  const lastGoodCheckpoint = checkpoints.find((checkpoint) => checkpoint.status === 'passed') || checkpoints[0] || null;
+  const lastGoodTask = [...(manifest?.tasks || [])].reverse().find((task) => task.status === 'passed') || null;
   const blockers = [
     ...(manifest?.tasks || [])
       .filter((task) => task.status === 'failed')
@@ -144,11 +120,11 @@ async function writeResumeIndex(repoRoot, changeId, state, manifest, report, opt
     `- Plan Version: ${manifest?.metadata?.planVersion || 1}`,
     `- Updated At: ${nowIso()}`,
     '',
-    '## Last Good Checkpoint',
+    '## Last Good Task',
     '',
-    lastGoodCheckpoint
-      ? `- \`${lastGoodCheckpoint.taskId}\` ${lastGoodCheckpoint.status} @ ${lastGoodCheckpoint.timestamp} - ${lastGoodCheckpoint.summary}`
-      : '- No checkpoint yet',
+    lastGoodTask
+      ? `- \`${lastGoodTask.id}\` ${lastGoodTask.status} - ${lastGoodTask.title || 'untitled task'}`
+      : '- No completed task yet',
     '',
     '## Blockers',
     '',
@@ -203,9 +179,9 @@ async function syncIntentPrBrief(repoRoot, changeId) {
   const summary = summarizeTaskStates(manifest.tasks || []);
   const touchedFiles = [...new Set((manifest.tasks || []).flatMap((task) => task.touches || []))];
   const skippedTasks = (manifest.tasks || []).filter((task) => task.status === 'skipped');
-  const checkpointRefs = (manifest.tasks || [])
+  const taskStatusRefs = (manifest.tasks || [])
     .filter((task) => isTaskSettledStatus(task.status))
-    .map((task) => `\`${task.id}\` ${task.title} -> \`devflow/changes/<change>/execution/tasks/${task.id}/checkpoint.json\``);
+    .map((task) => `\`${task.id}\` ${task.title} -> \`planning/tasks.md\` + \`planning/task-manifest.json\``);
 
   const risks = [
     ...((report.review?.status === 'skipped' || report.review?.status === 'blocked')
@@ -275,7 +251,7 @@ async function syncIntentPrBrief(repoRoot, changeId) {
       `\`devflow/changes/<change>/meta/change-state.json\``,
       `\`devflow/changes/<change>/planning/task-manifest.json\``,
       `\`devflow/changes/<change>/review/report-card.json\``,
-      ...checkpointRefs
+      ...taskStatusRefs
     ]),
     ''
   ].join('\n');

--- a/lib/skill-runtime/lifecycle.js
+++ b/lib/skill-runtime/lifecycle.js
@@ -205,7 +205,7 @@ function deriveLifecycleStage({ state, manifest, report, hasPrBrief = false }) {
 
 function describeExecutionNextAction({ failedTaskIds, runningTaskIds, pendingTaskIds, report }) {
   if (failedTaskIds.length > 0) {
-    return `优先修复失败任务 ${failedTaskIds.join(', ')}，然后从最近稳定 checkpoint 恢复。`;
+    return `优先修复失败任务 ${failedTaskIds.join(', ')}，然后从 task-manifest 的最近稳定状态恢复。`;
   }
 
   if (runningTaskIds.length > 0) {

--- a/lib/skill-runtime/operations/CLAUDE.md
+++ b/lib/skill-runtime/operations/CLAUDE.md
@@ -4,10 +4,10 @@
 阶段分组
 初始化与快照: `init.js` 创建 runtime 骨架，`snapshot.js` 采集 discover 阶段需要的只读事实。
 计划与批准: `plan.js` 生成 `task-manifest.json`，`approve.js` 锁定批准版本与执行模式。
-执行主链: `dispatch.js` 推进当前任务前沿，`resume.js` 从稳定 checkpoint 恢复，`verify.js` 和 `release.js` 负责质量门与发布收口。
+执行主链: `dispatch.js` 推进当前任务前沿，`resume.js` 从 `task-manifest.json` 的稳定状态恢复，`verify.js` 和 `release.js` 负责质量门与发布收口。
 交接与工人: `prepare-pr.js` 生成唯一 PR brief，`worker.js`/`worker-run.js` 负责本地或 provider worker handoff 与回写。
 自动驾驶: `autopilot-shared.js`、`autopilot-core.js`、`autopilot-execution.js`、`autopilot.js` 拆开共享语义、阶段判定和执行循环，避免单文件失控。
-维护类: `janitor.js` 清理过期 runtime 工件，但不改变正在运行任务的真相源。
+维护类: `janitor.js` 清理过期 runtime 工件，但不改变 manifest / tasks 的真相源。
 
 更新规则
 这里只记录阶段入口和职责边界，不维护逐文件穷举说明。

--- a/lib/skill-runtime/operations/dispatch.js
+++ b/lib/skill-runtime/operations/dispatch.js
@@ -1,24 +1,21 @@
 /**
- * [INPUT]: 依赖 manifest/checkpoint/events 与 shell 执行能力，接收并行度与重试参数。
- * [OUTPUT]: 更新 task-manifest 状态，写入每任务 events.jsonl 与 checkpoint.json。
+ * [INPUT]: 依赖 manifest/events 与 shell 执行能力，接收并行度与重试参数。
+ * [OUTPUT]: 更新 task-manifest 状态，失败或 debug 时写入每任务 events.jsonl。
  * [POS]: skill runtime Stage-4 执行入口，被内部执行与恢复链路复用。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
 const {
   nowIso,
-  ensureDir,
   appendJsonl,
   writeJson,
   readJson,
   runCommand,
   getTaskManifestPath,
   getRuntimeStatePath,
-  getRuntimeTaskDir,
-  getEventsPath,
-  getCheckpointPath
+  getEventsPath
 } = require('../store');
-const { parseManifest, parseCheckpoint } = require('../schemas');
+const { parseManifest } = require('../schemas');
 const { applyManifestExecutionState } = require('../planner');
 const { syncIntentMemory } = require('../intent');
 const {
@@ -84,12 +81,6 @@ function selectBatch(readyTasks, parallel) {
   return selected;
 }
 
-async function writeCheckpoint(repoRoot, changeId, taskId, payload, options = {}) {
-  const checkpointPath = getCheckpointPath(repoRoot, changeId, taskId);
-  const checkpoint = parseCheckpoint(payload);
-  await writeJson(checkpointPath, checkpoint);
-}
-
 async function writeEvent(repoRoot, changeId, taskId, event, debug = false) {
   if (!debug && !String(event.type || '').includes('failed') && !String(event.type || '').includes('rejected')) {
     return;
@@ -105,9 +96,6 @@ async function writeManifest(repoRoot, changeId, manifest) {
 }
 
 async function executeTask({ repoRoot, changeId, task, retryOverride, debug = false }) {
-  const taskRuntimeDir = getRuntimeTaskDir(repoRoot, changeId, task.id);
-  await ensureDir(taskRuntimeDir);
-
   const assignment = await findAssignment(repoRoot, changeId, task.id);
   const worker = await ensureWorkerWorkspace(repoRoot, changeId, assignment);
   const sessionId = toSessionId(task.id);
@@ -200,19 +188,6 @@ async function executeTask({ repoRoot, changeId, task, retryOverride, debug = fa
       task.status = 'passed';
       task.lastError = undefined;
 
-      await writeCheckpoint(repoRoot, changeId, task.id, {
-        changeId,
-        taskId: task.id,
-        sessionId,
-        planVersion: expectedPlanVersion,
-        status: task.status,
-        summary: `Task passed after ${task.attempts} attempt(s)`,
-        error: '',
-        outputExcerpt: '',
-        timestamp: nowIso(),
-        attempt: task.attempts
-      });
-
       await writeEvent(repoRoot, changeId, task.id, {
         type: 'task_passed',
         changeId,
@@ -245,19 +220,6 @@ async function executeTask({ repoRoot, changeId, task, retryOverride, debug = fa
 
     task.status = 'failed';
     task.lastError = failureMessage;
-
-    await writeCheckpoint(repoRoot, changeId, task.id, {
-      changeId,
-      taskId: task.id,
-      sessionId,
-      planVersion: expectedPlanVersion,
-      status: task.status,
-      summary: `Task failed: ${failureMessage.slice(0, 240)}`,
-      error: failureMessage,
-      outputExcerpt: failureMessage.slice(0, 400),
-      timestamp: nowIso(),
-      attempt: task.attempts
-    });
 
     await writeEvent(repoRoot, changeId, task.id, {
       type: failureMessage.includes('Stale result rejected') ? 'task_stale_rejected' : 'task_failed',

--- a/lib/skill-runtime/operations/init.js
+++ b/lib/skill-runtime/operations/init.js
@@ -11,7 +11,6 @@ const {
   writeJson,
   readJson,
   getChangeDir,
-  getRuntimeChangeDir,
   getRuntimeStatePath
 } = require('../store');
 const { getChangePaths, getChangeSlug } = require('../paths');
@@ -19,14 +18,11 @@ const { getChangePaths, getChangeSlug } = require('../paths');
 async function runInit({ repoRoot, changeId, goal }) {
   const changePaths = getChangePaths(repoRoot, changeId, { goal });
   const changeDir = getChangeDir(repoRoot, changeId, { goal });
-  const runtimeDir = getRuntimeChangeDir(repoRoot, changeId, { goal });
   const statePath = getRuntimeStatePath(repoRoot, changeId, { goal });
 
   await ensureDir(changeDir);
   await ensureDir(changePaths.metaDir);
   await ensureDir(changePaths.planningDir);
-  await ensureDir(runtimeDir);
-  await ensureDir(changePaths.tasksDir);
   await ensureDir(changePaths.reviewDir);
   await ensureDir(changePaths.handoffDir);
 
@@ -37,7 +33,7 @@ async function runInit({ repoRoot, changeId, goal }) {
     changeKey: changePaths.changeKey,
     slug: getChangeSlug(changeId, changePaths.changeKey),
     createdAt,
-    goal: goal || previous.goal || `Deliver ${changeId} safely with auditable checkpoints.`,
+    goal: goal || previous.goal || `Deliver ${changeId} safely with task-state truth.`,
     status: 'initialized',
     initializedAt: previous.initializedAt || nowIso(),
     approval: {
@@ -52,7 +48,7 @@ async function runInit({ repoRoot, changeId, goal }) {
   return {
     changeId,
     changeDir,
-    runtimeDir,
+    runtimeDir: changePaths.executionDir,
     changeKey: changePaths.changeKey,
     statePath,
     status: nextState.status

--- a/lib/skill-runtime/operations/janitor.js
+++ b/lib/skill-runtime/operations/janitor.js
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 devflow/changes 下 execution/tasks 目录与 checkpoint 状态，接收保留小时阈值。
- * [OUTPUT]: 删除过期且非运行中的任务运行态目录，并输出清理统计。
+ * [INPUT]: 依赖 devflow/changes 下 execution/tasks 目录与 mtime，接收保留小时阈值。
+ * [OUTPUT]: 删除过期任务运行态目录，并输出清理统计。
  * [POS]: skill runtime 熵清理入口，被 CLI `harness:janitor` 调用。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -8,24 +8,12 @@
 const fs = require('fs');
 const path = require('path');
 const {
-  readJson,
   listDirectories,
   getRuntimeRoot
 } = require('../store');
 
 async function removeDirectoryRecursive(dirPath) {
   await fs.promises.rm(dirPath, { recursive: true, force: true });
-}
-
-async function isTaskActive(taskDir) {
-  const checkpointPath = path.join(taskDir, 'checkpoint.json');
-  const checkpoint = await readJson(checkpointPath, null);
-
-  if (!checkpoint) {
-    return false;
-  }
-
-  return checkpoint.status === 'running';
 }
 
 async function runJanitor({ repoRoot, hours = 72 }) {
@@ -43,10 +31,6 @@ async function runJanitor({ repoRoot, hours = 72 }) {
       const stat = await fs.promises.stat(taskDir);
       const isStale = stat.mtimeMs < cutoffMs;
       if (!isStale) {
-        continue;
-      }
-
-      if (await isTaskActive(taskDir)) {
         continue;
       }
 

--- a/lib/skill-runtime/operations/resume.js
+++ b/lib/skill-runtime/operations/resume.js
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 manifest/checkpoint 当前状态与 dispatch 执行器，接收 changeId/并行度/重试参数。
- * [OUTPUT]: 将失败执行明确恢复到最近稳定 checkpoint，把未稳定任务重新排队后继续执行。
+ * [INPUT]: 依赖 manifest 当前状态与 dispatch 执行器，接收 changeId/并行度/重试参数。
+ * [OUTPUT]: 将失败执行恢复到最近已通过的 manifest 任务边界，把未稳定任务重新排队后继续执行。
  * [POS]: skill runtime 恢复执行入口，供内部恢复链路复用。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -9,8 +9,7 @@ const {
   readJson,
   writeJson,
   getTaskManifestPath,
-  getRuntimeStatePath,
-  getCheckpointPath
+  getRuntimeStatePath
 } = require('../store');
 const { parseManifest } = require('../schemas');
 const { applyManifestExecutionState } = require('../planner');
@@ -18,33 +17,17 @@ const { runDispatch } = require('./dispatch');
 const { syncIntentMemory } = require('../intent');
 const { getApprovalState, isExecutionApproved } = require('../lifecycle');
 
-async function resolveStableCheckpoint(repoRoot, changeId, manifest) {
-  const checkpoints = await Promise.all(
-    manifest.tasks.map(async (task) => {
-      const checkpoint = await readJson(getCheckpointPath(repoRoot, changeId, task.id), null);
-      if (!checkpoint) {
-        return null;
-      }
+async function resolveStableManifestPoint(manifest) {
+  const passedTasks = manifest.tasks
+    .filter((task) => task.status === 'passed')
+    .map((task) => ({
+      taskId: task.id,
+      status: task.status,
+      title: task.title || '',
+      planVersion: manifest.metadata?.planVersion || 1
+    }));
 
-      return {
-        taskId: task.id,
-        status: checkpoint.status,
-        timestamp: checkpoint.timestamp,
-        summary: checkpoint.summary,
-        planVersion: checkpoint.planVersion || null
-      };
-    })
-  );
-
-  const latestPassed = checkpoints
-    .filter((checkpoint) =>
-      checkpoint &&
-      checkpoint.status === 'passed' &&
-      checkpoint.planVersion === (manifest.metadata?.planVersion || 1)
-    )
-    .sort((left, right) => right.timestamp.localeCompare(left.timestamp))[0];
-
-  return latestPassed || null;
+  return passedTasks[passedTasks.length - 1] || null;
 }
 
 function restoreTaskToPending(task, restoreLabel) {
@@ -54,8 +37,8 @@ function restoreTaskToPending(task, restoreLabel) {
   task.lastError = `Restored from ${restoreLabel}.${previousError}`.trim();
 }
 
-function requeueFromStableCheckpoint(manifest, restoreTarget) {
-  const restoreLabel = restoreTarget ? `stable checkpoint ${restoreTarget.taskId}` : 'execution start';
+function requeueFromStableManifestPoint(manifest, restoreTarget) {
+  const restoreLabel = restoreTarget ? `stable manifest task ${restoreTarget.taskId}` : 'execution start';
   const restoredTaskIds = [];
 
   for (const task of manifest.tasks) {
@@ -106,16 +89,16 @@ async function runResume({
   }
 
   if (fromCheckpoint && fromCheckpoint !== 'stable') {
-    throw new Error(`Unsupported --from-checkpoint value: ${fromCheckpoint}`);
+    throw new Error(`Unsupported resume point: ${fromCheckpoint}`);
   }
 
-  const restoreTarget = await resolveStableCheckpoint(repoRoot, changeId, manifest);
-  const restoreSummary = requeueFromStableCheckpoint(manifest, restoreTarget);
+  const restoreTarget = await resolveStableManifestPoint(manifest);
+  const restoreSummary = requeueFromStableManifestPoint(manifest, restoreTarget);
 
   applyManifestExecutionState(manifest);
   await writeJson(manifestPath, manifest);
   await syncIntentMemory(repoRoot, changeId, {
-    event: 'resume_restored_checkpoint',
+    event: 'resume_restored_manifest_state',
     reason: restoreSummary.restoredTaskIds.length > 0
       ? `Restored ${restoreSummary.restoredTaskIds.join(', ')} from ${restoreSummary.restoreLabel}`
       : `Resume confirmed ${restoreSummary.restoreLabel}; no unresolved tasks required requeue`
@@ -132,7 +115,7 @@ async function runResume({
 
   return {
     ...dispatchResult,
-    restoredCheckpoint: restoreTarget,
+    restoredState: restoreTarget,
     restoredTasks: restoreSummary.restoredTaskIds,
     reason: dispatchResult.reason || `Resumed from ${restoreSummary.restoreLabel}`
   };

--- a/lib/skill-runtime/operations/snapshot.js
+++ b/lib/skill-runtime/operations/snapshot.js
@@ -28,7 +28,7 @@ async function collectGitFacts(repoRoot) {
 
 async function runPlanningSnapshot({ repoRoot, changeId, goal }) {
   const state = (await readJson(getRuntimeStatePath(repoRoot, changeId), {})) || {};
-  const effectiveGoal = goal || state.goal || `Deliver ${changeId} safely with auditable checkpoints.`;
+  const effectiveGoal = goal || state.goal || `Deliver ${changeId} safely with task-state truth.`;
   const gitFacts = await collectGitFacts(repoRoot);
   const scripts = await getPackageScripts(repoRoot);
 

--- a/lib/skill-runtime/operations/worker-run.js
+++ b/lib/skill-runtime/operations/worker-run.js
@@ -20,17 +20,14 @@ const {
   readJson,
   writeText,
   nowIso,
-  ensureDir,
   writeJson,
   appendJsonl,
   runCommand,
-  getRuntimeTaskDir,
-  getCheckpointPath,
   getEventsPath,
   getTaskManifestPath,
   getRuntimeStatePath
 } = require('../store');
-const { parseCheckpoint, parseManifest, parseRuntimeState } = require('../schemas');
+const { parseManifest, parseRuntimeState } = require('../schemas');
 const { applyManifestExecutionState } = require('../planner');
 const { syncIntentMemory } = require('../intent');
 const { namedError } = require('../errors');
@@ -356,11 +353,9 @@ async function runWorkerCommand({
   const sessionId = `${workerId}-${Date.now()}`;
   const startedAt = nowIso();
   const sessionLogPath = handoff.sessionLogPath || getWorkerSessionLogPath(repoRoot, changeId, workerId);
-  const runtimeTaskDir = getRuntimeTaskDir(repoRoot, changeId, primaryTaskId);
   const providerPromptPath = getProviderPromptPath(handoff, primaryTaskId);
   const providerLastMessagePath = getProviderLastMessagePath(handoff, primaryTaskId);
   const providerTranscriptPath = provider ? getProviderTranscriptPath(handoff, primaryTaskId, provider) : null;
-  await ensureDir(runtimeTaskDir);
   await markRuntimeInProgress(repoRoot, changeId);
   const providerPrompt = provider ? await buildProviderPrompt(repoRoot, handoff, primaryTaskId) : null;
   if (providerPrompt) {
@@ -452,12 +447,6 @@ async function runWorkerCommand({
   const finishedAt = nowIso();
   const finalStatus = result.code === 0 ? 'completed' : 'failed';
   const summary = summarizeOutput(result);
-  const providerOutputRaw = provider === 'codex'
-    ? await readText(providerLastMessagePath, '')
-    : provider === 'claude'
-      ? result.stdout
-      : result.stdout;
-  const providerOutput = providerOutputRaw.trim();
   const codexTranscript = provider === 'codex' ? parseCodexTranscript(result.stdout) : null;
 
   await appendSessionLog(sessionLogPath, [
@@ -471,25 +460,8 @@ async function runWorkerCommand({
     ''
   ].filter(Boolean));
 
-  const checkpointStatus = result.code === 0 ? 'passed' : 'failed';
-  const checkpointSummary = providerOutput
-    ? providerOutput.slice(0, 400)
-    : `${provider || 'custom'} execution ${checkpointStatus}`;
-  const checkpoint = parseCheckpoint({
-    changeId,
-    taskId: primaryTaskId,
-    sessionId,
-    planVersion: handoff.planVersion,
-    status: checkpointStatus,
-    summary: checkpointSummary,
-    error: result.code === 0 ? '' : (result.stderr || result.stdout || '').trim(),
-    outputExcerpt: providerOutput.slice(0, 400),
-    timestamp: finishedAt,
-    attempt: 1
-  });
-  await writeJson(getCheckpointPath(repoRoot, changeId, primaryTaskId), checkpoint);
   await updateManifestTaskState(repoRoot, changeId, primaryTaskId, {
-    status: checkpointStatus,
+    status: result.code === 0 ? 'passed' : 'failed',
     attempts: 1,
     lastError: result.code === 0 ? undefined : (result.stderr || result.stdout || '').trim()
   });

--- a/lib/skill-runtime/paths.js
+++ b/lib/skill-runtime/paths.js
@@ -225,7 +225,6 @@ function getTaskPaths(repoRoot, changeId, taskId, options = {}) {
     ...change,
     taskId,
     taskDir,
-    checkpointPath: path.join(taskDir, 'checkpoint.json'),
     eventsPath: path.join(taskDir, 'events.jsonl')
   };
 }

--- a/lib/skill-runtime/planner.js
+++ b/lib/skill-runtime/planner.js
@@ -513,7 +513,7 @@ async function createTaskManifest({ repoRoot, changeId, changeKey, goal, overwri
   const previousPlanVersion = previous?.metadata?.planVersion || 0;
   const manifest = applyManifestExecutionState({
     changeId,
-    goal: goal || `Deliver ${changeId} safely with auditable checkpoints.`,
+    goal: goal || `Deliver ${changeId} safely with task-state truth.`,
     createdAt: previous?.createdAt || nowIso(),
     updatedAt: nowIso(),
     currentTaskId: null,

--- a/lib/skill-runtime/query-registry.js
+++ b/lib/skill-runtime/query-registry.js
@@ -59,7 +59,7 @@ function createQueryRegistry(entries) {
           `Missing required query artifact: ${missingRefs.join(', ')}`,
           {
             artifactRefs: missingRefs,
-            rescueAction: 'create required runtime artifacts before running this query'
+            rescueAction: 'create required workflow artifacts before running this query'
           }
         );
       }
@@ -84,7 +84,7 @@ function createQueryRegistry(entries) {
           event: `query.${queryId}.failed`,
           changeId: context.changeId,
           artifactRefs,
-          nextAction: error.rescueAction || 'inspect-runtime-artifacts'
+          nextAction: error.rescueAction || 'inspect-workflow-artifacts'
         })
       };
     }

--- a/lib/skill-runtime/query.js
+++ b/lib/skill-runtime/query.js
@@ -39,7 +39,7 @@ async function readQueryArtifact(filePath, { required = true } = {}) {
         `Missing required query artifact: ${filePath}`,
         {
           artifactRefs: [filePath],
-          rescueAction: 'create required runtime artifacts before running this query'
+          rescueAction: 'create required workflow artifacts before running this query'
         }
       );
     }
@@ -55,7 +55,7 @@ async function readQueryArtifact(filePath, { required = true } = {}) {
       `Invalid query artifact ${filePath}: ${error.message}`,
       {
         artifactRefs: [filePath],
-        rescueAction: 'repair or regenerate the invalid runtime artifact before running this query',
+        rescueAction: 'repair or regenerate the invalid workflow artifact before running this query',
         details: {
           cause: error.name || 'Error'
         }

--- a/lib/skill-runtime/schemas.js
+++ b/lib/skill-runtime/schemas.js
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 zod 进行运行时 schema 校验，依赖调用方提供 manifest/report/checkpoint 原始对象。
- * [OUTPUT]: 对外提供 Manifest/Task/ReportCard/Checkpoint/Runtime approval schema 与 parse 校验函数。
+ * [INPUT]: 依赖 zod 进行运行时 schema 校验，依赖调用方提供 manifest/report/runtime 原始对象。
+ * [OUTPUT]: 对外提供 Manifest/Task/ReportCard/Runtime approval schema 与 parse 校验函数。
  * [POS]: skill runtime 的类型边界层，被 planner/dispatcher/verifier/release 复用。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */

--- a/lib/skill-runtime/store.js
+++ b/lib/skill-runtime/store.js
@@ -80,14 +80,6 @@ function getEventsPath(repoRoot, changeId, taskId, options = {}) {
   return getTaskPaths(repoRoot, changeId, taskId, options).eventsPath;
 }
 
-function getCheckpointPath(repoRoot, changeId, taskId, options = {}) {
-  return getTaskPaths(repoRoot, changeId, taskId, options).checkpointPath;
-}
-
-function getTaskReviewPath(repoRoot, changeId, taskId, kind, options = {}) {
-  return path.join(getTaskPaths(repoRoot, changeId, taskId, options).taskDir, `review-${kind}.md`);
-}
-
 async function exists(filePath) {
   try {
     await fsp.access(filePath);
@@ -239,8 +231,6 @@ module.exports = {
   getRuntimeChangeDir,
   getRuntimeTaskDir,
   getEventsPath,
-  getCheckpointPath,
-  getTaskReviewPath,
   exists,
   ensureDir,
   readText,

--- a/lib/skill-runtime/workflow-context.js
+++ b/lib/skill-runtime/workflow-context.js
@@ -12,7 +12,6 @@ const {
   getTaskManifestPath,
   getReportCardPath,
   getTasksMarkdownPath,
-  getCheckpointPath,
   exists,
   readJson,
   readText
@@ -62,7 +61,7 @@ async function readWorkflowArtifact(filePath, { required = true } = {}) {
         `Missing required query artifact: ${filePath}`,
         {
           artifactRefs: [filePath],
-          rescueAction: 'create required runtime artifacts before running this query'
+          rescueAction: 'create required workflow artifacts before running this query'
         }
       );
     }
@@ -78,7 +77,7 @@ async function readWorkflowArtifact(filePath, { required = true } = {}) {
       `Invalid query artifact ${filePath}: ${error.message}`,
       {
         artifactRefs: [filePath],
-        rescueAction: 'repair or regenerate the invalid runtime artifact before running this query',
+        rescueAction: 'repair or regenerate the invalid workflow artifact before running this query',
         details: {
           cause: error.name || 'Error'
         }
@@ -416,7 +415,6 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
   const progress = deriveTaskProgress(manifest.tasks || []);
   const queues = deriveTaskQueues(manifest);
   const nextTask = selectNextTask(manifest, queues);
-  const checkpointPath = nextTask ? getCheckpointPath(repoRoot, changeId, nextTask.id, options) : null;
   const relativeContractPath = canonicalContractPath ? relativePath(repoRoot, canonicalContractPath) : null;
   const relativeDesignPath = await maybeRelativePath(repoRoot, designPath);
   const relativeAnalysisPath = await maybeRelativePath(repoRoot, analysisPath);
@@ -425,7 +423,6 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
   const relativeChangeMetaPath = await maybeRelativePath(repoRoot, changeMetaPath);
   const relativeStatePath = await maybeRelativePath(repoRoot, statePath);
   const relativeReportPath = await maybeRelativePath(repoRoot, reportPath);
-  const relativeCheckpointPath = checkpointPath ? await maybeRelativePath(repoRoot, checkpointPath) : null;
   const relativePrimaryContractRef = relativeContractPath && contractResolution.fragment
     ? withFragment(relativeContractPath, contractResolution.fragment)
     : relativeContractPath;
@@ -447,8 +444,7 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
     relativeManifestPath,
     relativeChangeMetaPath,
     relativeStatePath,
-    relativeReportPath,
-    relativeCheckpointPath
+    relativeReportPath
   };
   const queryCommand = [
     'cc-devflow query workflow-context',
@@ -464,7 +460,6 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
     tasksPath,
     changeMetaPath,
     reportPath,
-    checkpointPath,
     refs
   });
   const defaultOpen = await validateOpenRefs(
@@ -543,10 +538,10 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
         'verification_failed == true',
         'missingVerificationCommands == true',
         'report.reroute != none',
-        'checkpoint_needed == true'
+        'runtime_log_needed == true'
       ],
       refs: [
-        { ref: relativeCheckpointPath, reason: 'current task recovery checkpoint' },
+        { ref: relativeTasksPath, reason: 'current task status and completion marks' },
         { ref: relativeReportPath, reason: 'latest review gate verdict' },
         { ref: relativeManifestPath, reason: 'verification command source' }
       ].filter((entry) => entry.ref),
@@ -633,7 +628,7 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
         ? 'current task has no executable verification command'
         : null,
       failClosed: [
-        'If manifest, contract, change-meta, report-card, or checkpoint hash changed after packet generation, rerun workflow-context.',
+        'If manifest, contract, change-meta, report-card, tasks, or Git state changed after packet generation, rerun workflow-context.',
         'If current task status is running, in_progress, active, blocked, needs_fix, or failed, resume it before selecting another ready task.',
         'If verification command is missing, route to cc-plan repair-task-verification instead of cc-do.',
         'If scope, ownership, dependency, or source confidence is uncertain, open the source artifact before acting.'
@@ -696,10 +691,10 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
           conditions: [
             'verification_failed == true',
             'report.reroute != none',
-            'checkpoint_needed == true'
+            'runtime_log_needed == true'
           ],
           open: dedupeOpenRefs([
-            openRef(relativeCheckpointPath, 'current task recovery checkpoint', source),
+            openRef(relativeTasksPath, 'current task status and completion marks', source),
             openRef(relativeReportPath, 'latest review gate verdict', source),
             openRef(relativeManifestPath, 'verification command source', source)
           ])
@@ -735,8 +730,7 @@ async function getWorkflowContext(repoRoot, changeId, options = {}) {
       relativeTasksPath,
       relativeManifestPath,
       relativeChangeMetaPath,
-      relativeReportPath,
-      relativeCheckpointPath
+      relativeReportPath
     ]),
     planningMeta: {
       planVersion: manifest.metadata?.planVersion || null,


### PR DESCRIPTION
## Summary
- add the review-ledger/task-contract runtime foundation already present in this worktree
- stop cc-do/runtime execution from generating task context.md and checkpoint.json files by default
- keep failed/debug execution details in optional CLI events.jsonl and make manifest/tasks/Git state the task truth
- update cc-plan/cc-do skill contracts, examples, and docs so downstream plans no longer request AI-written process files

## Test Plan
- [x] rtk npm test -- --runInBand
- [x] rtk npm run verify:examples
- [x] rtk npm run verify:publish
- [x] rtk npm run adapt:check
- [x] rtk git diff --check

## Notes
- This PR is for cc-devflow only. The explainer-comic REQ-064 artifact cleanup belongs to its existing PR branch, not this repository.