### PR TITLE
feat(cc-act): 增加尸检触发门禁

### DIFF
--- a/.claude/skills/cc-act/CHANGELOG.md
+++ b/.claude/skills/cc-act/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CC-Act Skill Changelog
 
+## v1.9.3 - 2026-05-17
+
+- add `evaluate-postmortem-trigger.sh` so FIX closeout, task-recorded incident markers, and session rework triggers produce an explicit postmortem gate decision
+- render the postmortem trigger verdict into `pr-brief.md` so handoff material records whether an incident postmortem is required
+- require final closeout to report either `POSTMORTEM_REQUIRED=no` or the written incident path instead of relying on implicit model memory
+
 ## v1.9.2 - 2026-05-17
 
 - make `render-pr-brief.sh` resolve `Output language` from `task.md` or runtime config and render PR handoff headings, metadata, and placeholders in Chinese when configured

--- a/.claude/skills/cc-act/PLAYBOOK.md
+++ b/.claude/skills/cc-act/PLAYBOOK.md
@@ -19,10 +19,10 @@ Everything else is Git history, PR history, or final response.
 2. Run or cite the current validation commands.
 3. Commit any remaining owned changes.
 4. Build `pr-brief.md` only when PR/handoff needs it.
-5. Write incident postmortem only when triggered.
+5. Run `evaluate-postmortem-trigger.sh`; write incident postmortem when it returns `POSTMORTEM_REQUIRED=yes`.
 6. Push/create/update PR when requested and available.
 7. Archive completed change only after merge or explicit closeout.
 
 ## Blockers
 
-Return to `cc-check` when evidence changed. Return to `cc-do` when implementation is unfinished. Do not patch around missing proof in Act.
+Return to `cc-check` when evidence changed. Return to `cc-do` when implementation is unfinished. If the postmortem gate depends on session-only rework evidence, pass it as `--trigger <short-label>` instead of silently dropping it. Do not patch around missing proof in Act.

--- a/.claude/skills/cc-act/SKILL.md
+++ b/.claude/skills/cc-act/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-act
-version: 1.9.2
+version: 1.9.3
 description: Use when verified work must be committed, handed off, pushed, or turned into a PR with the smallest durable delivery surface.
 triggers:
   - 准备提 PR
@@ -19,6 +19,7 @@ reads:
   - docs/guides/project-postmortem.md
   - ../cc-dev/scripts/resolve-cc-devflow.sh
   - scripts/ensure-ship-branch.sh
+  - scripts/evaluate-postmortem-trigger.sh
 writes:
   - path: devflow/changes/<change-key>/handoff/pr-brief.md
     durability: durable
@@ -39,12 +40,13 @@ effects:
 entry_gate:
   - "Resolve the CLI with `../cc-dev/scripts/resolve-cc-devflow.sh require config`."
   - "Read `task.md`, Git status, latest commits, validation evidence, and current PR state when relevant."
+  - "Run `scripts/evaluate-postmortem-trigger.sh --dir <change-dir>` before deciding no incident postmortem is needed."
   - "If verification changed during Act, return to `cc-check`."
   - "Pick one mode: `create-pr`, `update-pr`, `local-handoff`, or `post-merge-closeout`."
 exit_criteria:
   - "All completed work is committed with coherent Conventional Commit messages."
   - "PR mode writes or refreshes only `handoff/pr-brief.md`."
-  - "FIX or recurring failure closeout writes incident postmortem only when needed."
+  - "Postmortem trigger gate is explicit: either `POSTMORTEM_REQUIRED=no` is reported, or the incident postmortem path is written."
   - "No process file is created beyond the allowed durable outputs."
   - "Push, PR, or local handoff status is explicit."
 reroutes:
@@ -83,11 +85,19 @@ tool_budget:
 
 ## Postmortem
 
+先运行：
+
+```bash
+scripts/evaluate-postmortem-trigger.sh --dir devflow/changes/<change-key>
+```
+
 只在这些情况写 incident postmortem：
 
 1. change key 是 `FIX-*`。
 2. 暴露重复 AI、流程、测试、release、Git 或架构错误。
 3. 用户明确要求记录教训。
+
+如果本轮会话出现了返工、reroute、三次修补仍失败、发布/Git/验证工具异常，但这些信号还没有进入 `task.md` 或 Git history，调用脚本时用 `--trigger <short-label>` 把会话证据纳入本次 gate。没有触发时，最终响应也必须写明 `POSTMORTEM_REQUIRED=no`。
 
 尸检报告必须基于 Git 证据和验证命令。不要把教训拆成额外原则文件。
 

--- a/.claude/skills/cc-act/assets/PR_BRIEF_TEMPLATE.md
+++ b/.claude/skills/cc-act/assets/PR_BRIEF_TEMPLATE.md
@@ -21,6 +21,12 @@
 
 - <diff summary>
 
+## Postmortem Trigger
+
+- Postmortem required: yes / no
+- Triggers:
+- Incident path:
+
 ## Validation
 
 - Command:

--- a/.claude/skills/cc-act/references/closure-contract.md
+++ b/.claude/skills/cc-act/references/closure-contract.md
@@ -11,8 +11,9 @@
 1. Git commits are the process record.
 2. PR text is rebuilt from current commits, diff, `task.md`, and fresh validation.
 3. Incident postmortems are factual and evidence-backed.
-4. No process file beyond the allowed durable outputs.
-5. If verification changes during Act, return to `cc-check`.
+4. `cc-act` must make the postmortem trigger decision explicit with `POSTMORTEM_REQUIRED=yes/no`.
+5. No process file beyond the allowed durable outputs.
+6. If verification changes during Act, return to `cc-check`.
 
 ## Exit
 

--- a/.claude/skills/cc-act/scripts/evaluate-postmortem-trigger.sh
+++ b/.claude/skills/cc-act/scripts/evaluate-postmortem-trigger.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: evaluate-postmortem-trigger.sh --dir path/to/change [--repo-root path/to/repo] [--date YYYY-MM-DD] [--trigger label]
+EOF
+}
+
+REQ_DIR=""
+REPO_ROOT=""
+TODAY=""
+SESSION_TRIGGERS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) REQ_DIR="$2"; shift 2 ;;
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --date) TODAY="$2"; shift 2 ;;
+    --trigger)
+      SESSION_TRIGGERS="${SESSION_TRIGGERS}${SESSION_TRIGGERS:+$'\n'}$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$REQ_DIR" || ! -d "$REQ_DIR" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ -z "$TODAY" ]]; then
+  TODAY="$(date +%F)"
+fi
+
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT="$(git -C "$REQ_DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$script_dir/cc-act-common.sh"
+
+change_dir="$(req_act_change_dir "$REQ_DIR")"
+task_file="$(req_act_tasks_path "$change_dir")"
+change_key="$(basename "$change_dir")"
+incident_path="devflow/postmortems/incidents/$TODAY-$change_key.md"
+index_path="devflow/postmortems/INDEX.md"
+triggers=""
+
+add_trigger() {
+  local trigger="$1"
+
+  [[ -n "$trigger" ]] || return 0
+  triggers="${triggers}${triggers:+$'\n'}$trigger"
+}
+
+if [[ "$change_key" == FIX-* ]]; then
+  add_trigger "change-key:FIX"
+fi
+
+if [[ -f "$task_file" ]]; then
+  if rg -i --quiet 'postmortem[ -]?(required|signal|trigger)[: ]+(yes|required|true)' "$task_file"; then
+    add_trigger "task:postmortem-required"
+  fi
+  if rg -i --quiet '(incident|failure|reroute|rework)[ -]?postmortem[: ]+(yes|required|true)' "$task_file"; then
+    add_trigger "task:incident-postmortem"
+  fi
+fi
+
+while IFS= read -r trigger; do
+  [[ -n "$trigger" ]] || continue
+  add_trigger "session:$trigger"
+done <<< "$SESSION_TRIGGERS"
+
+if [[ -n "$triggers" ]]; then
+  required="yes"
+  trigger_text="$(printf '%s\n' "$triggers" | awk 'NF && !seen[$0]++' | paste -sd ',' -)"
+else
+  required="no"
+  trigger_text="none"
+fi
+
+cat <<EOF
+POSTMORTEM_REQUIRED=$required
+CHANGE_KEY=$change_key
+TRIGGERS=$trigger_text
+INDEX_PATH=$index_path
+INCIDENT_PATH=$incident_path
+TASK_FILE=$task_file
+EOF

--- a/.claude/skills/cc-act/scripts/render-pr-brief.sh
+++ b/.claude/skills/cc-act/scripts/render-pr-brief.sh
@@ -49,6 +49,16 @@ head_sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
 status="$(git -C "$REPO_ROOT" status --short 2>/dev/null || true)"
 commits="$(git -C "$REPO_ROOT" log --oneline -10 2>/dev/null || true)"
 changed="$(git -C "$REPO_ROOT" diff --stat HEAD 2>/dev/null || true)"
+postmortem_context="$("$script_dir/evaluate-postmortem-trigger.sh" --dir "$change_dir" --repo-root "$REPO_ROOT")"
+
+postmortem_field() {
+  local key="$1"
+  printf '%s\n' "$postmortem_context" | awk -F= -v key="$key" '$1 == key { sub("^[^=]*=", ""); print; exit }'
+}
+
+postmortem_required="$(postmortem_field POSTMORTEM_REQUIRED)"
+postmortem_triggers="$(postmortem_field TRIGGERS)"
+postmortem_incident="$(postmortem_field INCIDENT_PATH)"
 
 trim() {
   sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
@@ -99,6 +109,10 @@ if [[ "$output_language" == "zh-CN" ]]; then
   no_diff="没有未提交差异"
   status_heading="工作树状态"
   clean_status="干净"
+  postmortem_heading="尸检触发"
+  postmortem_required_label="是否需要尸检"
+  postmortem_triggers_label="触发原因"
+  postmortem_incident_label="尸检路径"
   body_heading="PR 正文草稿"
   summary_label="摘要"
   summary_placeholder="<根据 task.md 和提交记录总结用户可见变化>"
@@ -121,6 +135,10 @@ else
   no_diff="No uncommitted diff"
   status_heading="Worktree Status"
   clean_status="Clean"
+  postmortem_heading="Postmortem Trigger"
+  postmortem_required_label="Postmortem required"
+  postmortem_triggers_label="Triggers"
+  postmortem_incident_label="Incident path"
   body_heading="PR Body Draft"
   summary_label="Summary"
   summary_placeholder="<summarize user-visible change from task.md and commits>"
@@ -170,6 +188,14 @@ render_prefixed_lines() {
   echo "## $status_heading"
   echo
   render_prefixed_lines "$status" "$clean_status"
+  echo
+  echo "## $postmortem_heading"
+  echo
+  echo "- $postmortem_required_label: ${postmortem_required:-unknown}"
+  echo "- $postmortem_triggers_label: ${postmortem_triggers:-none}"
+  if [[ "${postmortem_required:-no}" == "yes" ]]; then
+    echo "- $postmortem_incident_label: ${postmortem_incident:-unknown}"
+  fi
   echo
   echo "## $body_heading"
   echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [4.5.17] - 2026-05-17
+
+### Added
+
+- Added an explicit `cc-act` postmortem trigger gate through `evaluate-postmortem-trigger.sh`.
+- Added `pr-brief.md` postmortem trigger output so closeout records whether an incident postmortem is required.
+
+### Changed
+
+- Updated `cc-act` to require `POSTMORTEM_REQUIRED=yes/no` before declaring closeout complete.
+- Updated project postmortem guidance so session-only rework, reroutes, or tool failures can be passed into the gate with `--trigger`.
+
 ## [4.5.16] - 2026-05-17
 
 ### Changed

--- a/docs/examples/example-bindings.json
+++ b/docs/examples/example-bindings.json
@@ -11,7 +11,7 @@
     "cc-pr-review": "1.1.3",
     "cc-pr-land": "1.1.0",
     "cc-check": "1.12.2",
-    "cc-act": "1.9.2",
+    "cc-act": "1.9.3",
     "cc-spec-init": "1.2.0"
   },
   "examples": [

--- a/docs/examples/local-handoff/README.md
+++ b/docs/examples/local-handoff/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.3.1`, `cc-plan@3.10.7`, `cc-do@1.7.2`, `cc-check@1.12.2`, `cc-act@1.9.2`
+- Bound skills: `cc-roadmap@5.3.1`, `cc-plan@3.10.7`, `cc-do@1.7.2`, `cc-check@1.12.2`, `cc-act@1.9.3`
 
 This example shows verified work that is **ready to move forward**, but `cc-act` still chooses `local-handoff`.
 

--- a/docs/examples/pdca-loop/README.md
+++ b/docs/examples/pdca-loop/README.md
@@ -4,7 +4,7 @@
 
 - Example version: `1.0.0`
 - Last reviewed: `2026-04-17`
-- Bound skills: `cc-roadmap@5.3.1`, `cc-plan@3.10.7`, `cc-do@1.7.2`, `cc-check@1.12.2`, `cc-act@1.9.2`
+- Bound skills: `cc-roadmap@5.3.1`, `cc-plan@3.10.7`, `cc-do@1.7.2`, `cc-check@1.12.2`, `cc-act@1.9.3`
 
 This folder shows one minimal but complete `cc-roadmap -> cc-plan -> cc-do -> cc-check -> cc-act` loop.
 

--- a/docs/guides/project-postmortem.md
+++ b/docs/guides/project-postmortem.md
@@ -13,6 +13,14 @@ Postmortems preserve recurring failures without turning every workflow step into
 - repeated AI, test, release, Git, or architecture failure
 - explicit user request
 
+`cc-act` must make the decision explicit by running:
+
+```bash
+.claude/skills/cc-act/scripts/evaluate-postmortem-trigger.sh --dir devflow/changes/<change-key>
+```
+
+If the trigger only exists in the current session, pass it as `--trigger <short-label>` so the final closeout does not silently drop rework or unusual failure evidence.
+
 ## Rules
 
 - Use Git evidence, commands, and current files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cc-devflow",
-    "version": "4.5.16",
+    "version": "4.5.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cc-devflow",
-            "version": "4.5.16",
+            "version": "4.5.17",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cc-devflow",
-    "version": "4.5.16",
+    "version": "4.5.17",
     "description": "Multi-platform CLI and skill pack for agent coding",
     "main": "bin/cc-devflow.js",
     "bin": {

--- a/test/cc-act-render-pr-brief.test.js
+++ b/test/cc-act-render-pr-brief.test.js
@@ -8,6 +8,10 @@ const RENDER_PR_BRIEF = path.join(
   REPO_ROOT,
   '.claude/skills/cc-act/scripts/render-pr-brief.sh'
 );
+const EVALUATE_POSTMORTEM_TRIGGER = path.join(
+  REPO_ROOT,
+  '.claude/skills/cc-act/scripts/evaluate-postmortem-trigger.sh'
+);
 
 function run(command, args, cwd) {
   const result = spawnSync(command, args, {
@@ -70,7 +74,85 @@ describe('cc-act PR brief renderer', () => {
       expect(rendered).toContain('## 任务摘要');
       expect(rendered).toContain('- 已完成: T001 Finish demo task');
       expect(rendered).toContain('## PR 正文草稿');
+      expect(rendered).toContain('## 尸检触发');
+      expect(rendered).toContain('- 是否需要尸检: no');
       expect(rendered).toContain('- <根据 task.md 和提交记录总结用户可见变化>');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('cc-act postmortem trigger evaluator', () => {
+  function createRepo(changeKey, taskLines = []) {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-act-postmortem-'));
+    const changeDir = path.join(repoRoot, 'devflow/changes', changeKey);
+
+    fs.mkdirSync(changeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(changeDir, 'task.md'),
+      [
+        '# task.md',
+        '',
+        '## Tasks',
+        '',
+        '- [x] T001 Finish task',
+        ...taskLines,
+        ''
+      ].join('\n')
+    );
+
+    run('git', ['init'], repoRoot);
+    run('git', ['config', 'user.name', 'Test User'], repoRoot);
+    run('git', ['config', 'user.email', 'test@example.com'], repoRoot);
+    run('git', ['add', '.'], repoRoot);
+    run('git', ['commit', '-m', 'test: seed task'], repoRoot);
+
+    return { repoRoot, changeDir };
+  }
+
+  test('requires a postmortem for FIX change keys', () => {
+    const { repoRoot, changeDir } = createRepo('FIX-001-broken-closeout');
+
+    try {
+      const result = run(
+        'bash',
+        [EVALUATE_POSTMORTEM_TRIGGER, '--dir', changeDir, '--date', '2026-05-17'],
+        repoRoot
+      );
+
+      expect(result.stdout).toContain('POSTMORTEM_REQUIRED=yes');
+      expect(result.stdout).toContain('TRIGGERS=change-key:FIX');
+      expect(result.stdout).toContain(
+        'INCIDENT_PATH=devflow/postmortems/incidents/2026-05-17-FIX-001-broken-closeout.md'
+      );
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('carries task and session postmortem triggers into the gate decision', () => {
+    const { repoRoot, changeDir } = createRepo('REQ-001-demo', [
+      '',
+      '- Postmortem signal: yes'
+    ]);
+
+    try {
+      const result = run(
+        'bash',
+        [
+          EVALUATE_POSTMORTEM_TRIGGER,
+          '--dir',
+          changeDir,
+          '--trigger',
+          'cc-check-reroute'
+        ],
+        repoRoot
+      );
+
+      expect(result.stdout).toContain('POSTMORTEM_REQUIRED=yes');
+      expect(result.stdout).toContain('task:postmortem-required');
+      expect(result.stdout).toContain('session:cc-check-reroute');
     } finally {
       fs.rmSync(repoRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add an explicit cc-act postmortem trigger gate with `evaluate-postmortem-trigger.sh`
- render `POSTMORTEM_REQUIRED` truth into PR handoff output
- release `cc-devflow@4.5.17` with changelog and package-lock sync

## Test Plan
- [x] npm test -- --runInBand
- [x] npm run verify:examples
- [x] npm run verify:publish
- [x] npm run adapt:check
- [x] npm publish --dry-run --access public
- [x] npm publish --access public
- [x] npm view cc-devflow@4.5.17 bin --json
- [x] npx --yes cc-devflow@4.5.17 --help

## Release
- Published: `cc-devflow@4.5.17`
- Tag: `v4.5.17`