### PR TITLE
Add Managed Resource Copy manifest

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,12 @@ _Avoid_: Public skill, command skill
 A skill that exists for other skills and agents to reuse inside the workflow chain, rather than as a primary human entry point.
 _Avoid_: Shared reference, helper doc
 
+**Managed Resource Copy**:
+A bundled resource file copied into one or more skill-local paths from an owner
+resource so host adapters, package consumers, and generated mirrors can resolve
+relative paths without treating each copy as a separate source of truth.
+_Avoid_: Chain Skill, shared reference, generated mirror
+
 **Capability Skill**:
 A reusable skill that can be invoked directly and consulted by workflow skills
 without becoming a PDCA stage. `cc-research` is a Capability Skill and owns

--- a/config/managed-resource-copies.json
+++ b/config/managed-resource-copies.json
@@ -1,0 +1,17 @@
+{
+  "managedResourceCopies": [
+    {
+      "name": "git-commit-guidelines",
+      "owner": ".claude/skills/cc-act/references/git-commit-guidelines.md",
+      "copies": [
+        ".claude/skills/cc-check/references/git-commit-guidelines.md",
+        ".claude/skills/cc-dev/references/git-commit-guidelines.md",
+        ".claude/skills/cc-diagnose/references/git-commit-guidelines.md",
+        ".claude/skills/cc-do/references/git-commit-guidelines.md",
+        ".claude/skills/cc-plan/references/git-commit-guidelines.md",
+        ".claude/skills/npm-release/references/git-commit-guidelines.md"
+      ],
+      "policy": "must-match"
+    }
+  ]
+}

--- a/docs/adr/0009-managed-resource-copies.md
+++ b/docs/adr/0009-managed-resource-copies.md
@@ -1,0 +1,8 @@
+# Keep Managed Resource Copies Skill-Local
+
+cc-devflow will keep bundled resource files such as `git-commit-guidelines.md`
+copied into skill-local paths instead of moving them into a shared directory,
+because host adapters, package consumers, and generated mirrors need stable
+relative paths inside each skill. Drift for identical copies will be controlled
+by an owner-plus-copies manifest and publish gate, while intentionally different
+copies remain local variants with an explicit reason.

--- a/scripts/validate-publish.js
+++ b/scripts/validate-publish.js
@@ -9,10 +9,10 @@ const { validateSkillInventory } = require('../lib/compiler/inventory');
 
 const ROOT = path.resolve(__dirname, '..');
 const DISTRIBUTION_CONFIG = require(path.join(ROOT, 'config', 'distributable-skills.json'));
+const MANAGED_RESOURCE_CONFIG = require(path.join(ROOT, 'config', 'managed-resource-copies.json'));
 const PUBLIC_SKILLS = DISTRIBUTION_CONFIG.publicSkills || [];
 const DISTRIBUTED_SKILLS = DISTRIBUTION_CONFIG.distributedSkills || PUBLIC_SKILLS;
 const INTERNAL_SKILLS = DISTRIBUTION_CONFIG.internalSkills || [];
-const COMMIT_GUIDELINE_SKILLS = ['cc-plan', 'cc-dev', 'cc-do', 'cc-check', 'cc-diagnose', 'cc-act', 'npm-release'];
 const COMMIT_GUIDELINE_REF = 'references/git-commit-guidelines.md';
 
 const RETIRED_PATTERNS = [
@@ -34,7 +34,11 @@ const RETIRED_PATTERNS = [
 ];
 
 function ensurePath(relPath, expectedType, errors) {
-  const target = path.join(ROOT, relPath);
+  ensurePathFrom(ROOT, relPath, expectedType, errors);
+}
+
+function ensurePathFrom(root, relPath, expectedType, errors) {
+  const target = path.join(root, relPath);
   if (!fs.existsSync(target)) {
     errors.push(`Missing ${expectedType}: ${relPath}`);
     return;
@@ -48,7 +52,11 @@ function ensurePath(relPath, expectedType, errors) {
 }
 
 function readText(relPath) {
-  return fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+  return readTextFrom(ROOT, relPath);
+}
+
+function readTextFrom(root, relPath) {
+  return fs.readFileSync(path.join(root, relPath), 'utf8');
 }
 
 function validatePackageJson(errors) {
@@ -222,18 +230,67 @@ function validateSkillFrontmatter(errors) {
   }
 }
 
-function validateCommitGuidelineRefs(errors) {
-  const canonical = readText('.claude/skills/cc-act/references/git-commit-guidelines.md');
+function validateManagedResourceCopies(errors, options = {}) {
+  const root = options.root || ROOT;
+  const manifest = options.manifest || MANAGED_RESOURCE_CONFIG;
+  if (!Array.isArray(manifest?.managedResourceCopies)) {
+    errors.push('config/managed-resource-copies.json managedResourceCopies must be an array');
+    return;
+  }
 
-  for (const skillName of COMMIT_GUIDELINE_SKILLS) {
+  for (const group of manifest.managedResourceCopies) {
+    const name = group?.name || '<unnamed>';
+    const owner = group?.owner;
+    const copies = Array.isArray(group?.copies) ? group.copies : [];
+    const policy = group?.policy || 'must-match';
+
+    if (!owner) {
+      errors.push(`Managed Resource Copy ${name} missing owner`);
+      continue;
+    }
+
+    ensurePathFrom(root, owner, 'file', errors);
+    for (const copy of copies) {
+      ensurePathFrom(root, copy, 'file', errors);
+    }
+
+    if (policy === 'variant') {
+      if (!String(group.variantReason || '').trim()) {
+        errors.push(`Managed Resource Copy ${name} uses policy variant but is missing variantReason`);
+      }
+      continue;
+    }
+
+    if (policy !== 'must-match') {
+      errors.push(`Managed Resource Copy ${name} has unknown policy: ${policy}`);
+      continue;
+    }
+
+    if (!fs.existsSync(path.join(root, owner))) continue;
+    const ownerText = readTextFrom(root, owner);
+    for (const copy of copies) {
+      if (fs.existsSync(path.join(root, copy)) && readTextFrom(root, copy) !== ownerText) {
+        errors.push(`Managed Resource Copy ${name} drift: ${copy} must match ${owner}`);
+      }
+    }
+  }
+}
+
+function validateCommitGuidelineRefs(errors) {
+  const commitGuidelines = MANAGED_RESOURCE_CONFIG.managedResourceCopies.find((group) => group.name === 'git-commit-guidelines');
+  if (!commitGuidelines) {
+    errors.push('config/managed-resource-copies.json missing git-commit-guidelines group');
+    return;
+  }
+
+  const guidelinePaths = [commitGuidelines.owner, ...(commitGuidelines.copies || [])];
+  for (const guidelineRel of guidelinePaths) {
+    const match = guidelineRel.match(/^\.claude\/skills\/([^/]+)\//);
+    if (!match) continue;
+    const skillName = match[1];
     const skillRel = `.claude/skills/${skillName}/SKILL.md`;
-    const guidelineRel = `.claude/skills/${skillName}/${COMMIT_GUIDELINE_REF}`;
     const skillText = readText(skillRel);
 
-    ensurePath(guidelineRel, 'file', errors);
-    if (fs.existsSync(path.join(ROOT, guidelineRel)) && readText(guidelineRel) !== canonical) {
-      errors.push(`${guidelineRel} must match the canonical commit guideline copy`);
-    }
     if (!skillText.includes(COMMIT_GUIDELINE_REF)) {
       errors.push(`${skillRel} must reference its local ${COMMIT_GUIDELINE_REF}`);
     }
@@ -332,6 +389,7 @@ function main() {
   validateTemplate(errors);
   validateInventoryParity(errors);
   validateSkillFrontmatter(errors);
+  validateManagedResourceCopies(errors);
   validateCommitGuidelineRefs(errors);
   validateNoRetiredFiles(errors);
   validateNoRetiredText(errors);
@@ -359,6 +417,7 @@ module.exports = {
   validateTemplate,
   validateInventoryParity,
   validateSkillFrontmatter,
+  validateManagedResourceCopies,
   validateCommitGuidelineRefs,
   validateNoRetiredFiles,
   validateNoRetiredText,

--- a/scripts/validate-publish.js
+++ b/scripts/validate-publish.js
@@ -276,20 +276,25 @@ function validateManagedResourceCopies(errors, options = {}) {
   }
 }
 
-function validateCommitGuidelineRefs(errors) {
-  const commitGuidelines = MANAGED_RESOURCE_CONFIG.managedResourceCopies.find((group) => group.name === 'git-commit-guidelines');
+function validateCommitGuidelineRefs(errors, options = {}) {
+  const root = options.root || ROOT;
+  const manifest = options.manifest || MANAGED_RESOURCE_CONFIG;
+  const groups = Array.isArray(manifest?.managedResourceCopies) ? manifest.managedResourceCopies : [];
+  const commitGuidelines = groups.find((group) => group.name === 'git-commit-guidelines');
   if (!commitGuidelines) {
     errors.push('config/managed-resource-copies.json missing git-commit-guidelines group');
     return;
   }
 
-  const guidelinePaths = [commitGuidelines.owner, ...(commitGuidelines.copies || [])];
+  if (!commitGuidelines.owner || !Array.isArray(commitGuidelines.copies)) return;
+
+  const guidelinePaths = [commitGuidelines.owner, ...commitGuidelines.copies];
   for (const guidelineRel of guidelinePaths) {
     const match = guidelineRel.match(/^\.claude\/skills\/([^/]+)\//);
     if (!match) continue;
     const skillName = match[1];
     const skillRel = `.claude/skills/${skillName}/SKILL.md`;
-    const skillText = readText(skillRel);
+    const skillText = readTextFrom(root, skillRel);
 
     if (!skillText.includes(COMMIT_GUIDELINE_REF)) {
       errors.push(`${skillRel} must reference its local ${COMMIT_GUIDELINE_REF}`);

--- a/test/validate-publish.test.js
+++ b/test/validate-publish.test.js
@@ -1,8 +1,15 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '..');
+const { validateManagedResourceCopies } = require('../scripts/validate-publish');
+
+function writeFile(filePath, content = '') {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
 
 describe('validate-publish', () => {
   test('publish validation passes', () => {
@@ -104,5 +111,52 @@ describe('validate-publish', () => {
     });
 
     expect(offenders).toEqual([]);
+  });
+
+  test('managed resource copies fail when strict copies drift', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'managed-resource-drift-'));
+    writeFile(path.join(root, 'owner.md'), 'same');
+    writeFile(path.join(root, 'copy.md'), 'different');
+
+    const errors = [];
+    validateManagedResourceCopies(errors, {
+      root,
+      manifest: {
+        managedResourceCopies: [{
+          name: 'sample',
+          owner: 'owner.md',
+          copies: ['copy.md'],
+          policy: 'must-match'
+        }]
+      }
+    });
+
+    expect(errors).toContain('Managed Resource Copy sample drift: copy.md must match owner.md');
+  });
+
+  test('managed resource copy variants need a reason', () => {
+    const errors = [];
+    validateManagedResourceCopies(errors, {
+      root: fs.mkdtempSync(path.join(os.tmpdir(), 'managed-resource-variant-')),
+      manifest: {
+        managedResourceCopies: [{
+          name: 'variant',
+          owner: 'owner.md',
+          copies: ['copy.md'],
+          policy: 'variant'
+        }]
+      }
+    });
+
+    expect(errors).toContain('Managed Resource Copy variant uses policy variant but is missing variantReason');
+  });
+
+  test('managed resource copy manifest shape fails closed', () => {
+    const errors = [];
+    validateManagedResourceCopies(errors, {
+      manifest: {}
+    });
+
+    expect(errors).toContain('config/managed-resource-copies.json managedResourceCopies must be an array');
   });
 });

--- a/test/validate-publish.test.js
+++ b/test/validate-publish.test.js
@@ -4,7 +4,10 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '..');
-const { validateManagedResourceCopies } = require('../scripts/validate-publish');
+const {
+  validateManagedResourceCopies,
+  validateCommitGuidelineRefs
+} = require('../scripts/validate-publish');
 
 function writeFile(filePath, content = '') {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -158,5 +161,22 @@ describe('validate-publish', () => {
     });
 
     expect(errors).toContain('config/managed-resource-copies.json managedResourceCopies must be an array');
+  });
+
+  test('publish validation reports missing managed resource owner without crashing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'managed-resource-missing-owner-'));
+    const errors = [];
+    const manifest = {
+      managedResourceCopies: [{
+        name: 'git-commit-guidelines',
+        copies: ['copy.md'],
+        policy: 'must-match'
+      }]
+    };
+
+    validateManagedResourceCopies(errors, { root, manifest });
+    expect(() => validateCommitGuidelineRefs(errors, { root, manifest })).not.toThrow();
+
+    expect(errors).toContain('Managed Resource Copy git-commit-guidelines missing owner');
   });
 });


### PR DESCRIPTION
## Summary
- add a Managed Resource Copy manifest for git-commit-guidelines
- validate manifest-managed copies in the publish gate
- document the skill-local copy decision in CONTEXT and ADR 0009

## Test plan
- npm test -- validate-publish
- npm run verify

## Issue closeout
Closes #48

## Branch cleanup
Delete source branch after merge.